### PR TITLE
Remove prev & next note links in zettelkasten

### DIFF
--- a/.astro/astro/content.d.ts
+++ b/.astro/astro/content.d.ts
@@ -494,6 +494,13 @@ declare module 'astro:content' {
   collection: "journal";
   data: any
 } & { render(): Render[".md"] };
+"transparency-is-not-sharing-everything.md": {
+	id: "transparency-is-not-sharing-everything.md";
+  slug: "transparency-is-not-sharing-everything";
+  body: string;
+  collection: "journal";
+  data: any
+} & { render(): Render[".md"] };
 "your-job-title-depends-on-the-organization.md": {
 	id: "your-job-title-depends-on-the-organization.md";
   slug: "your-job-title-depends-on-the-organization";
@@ -1418,6 +1425,13 @@ declare module 'astro:content' {
 "23h.md": {
 	id: "23h.md";
   slug: "23h";
+  body: string;
+  collection: "notes";
+  data: any
+} & { render(): Render[".md"] };
+"23i.md": {
+	id: "23i.md";
+  slug: "23i";
   body: string;
   collection: "notes";
   data: any
@@ -2997,6 +3011,13 @@ declare module 'astro:content' {
   collection: "notes";
   data: any
 } & { render(): Render[".md"] };
+"69a.md": {
+	id: "69a.md";
+  slug: "69a";
+  body: string;
+  collection: "notes";
+  data: any
+} & { render(): Render[".md"] };
 "7.md": {
 	id: "7.md";
   slug: "7";
@@ -3035,6 +3056,13 @@ declare module 'astro:content' {
 "73.md": {
 	id: "73.md";
   slug: "73";
+  body: string;
+  collection: "notes";
+  data: any
+} & { render(): Render[".md"] };
+"73a.md": {
+	id: "73a.md";
+  slug: "73a";
   body: string;
   collection: "notes";
   data: any
@@ -3112,6 +3140,13 @@ declare module 'astro:content' {
 "80.md": {
 	id: "80.md";
   slug: "80";
+  body: string;
+  collection: "notes";
+  data: any
+} & { render(): Render[".md"] };
+"81.md": {
+	id: "81.md";
+  slug: "81";
   body: string;
   collection: "notes";
   data: any

--- a/src/content/notes/1.md
+++ b/src/content/notes/1.md
@@ -18,5 +18,4 @@ There are many reasons why we must write:
 
 ---
 
-- **Next Note:** [1a: How Zettelkasten Works](/notes/1a/);
 - **Related Posts:** [How to Stop Endless Discussions](/how-to-stop-endless-discussions/); [Why is Writing Important?](/why-is-writing-important/);

--- a/src/content/notes/10.md
+++ b/src/content/notes/10.md
@@ -14,6 +14,4 @@ Ask yourself and answer truly: Do you imagine yourself in five years still codin
 
 ---
 
-- **Previous Note:** [9c: Simple Ideas Prevent Complicated Problems](/notes/9c/);
-- **Next Note:** [10a: Growing in IC track in Engineering](/notes/10a/);
 - **Related Note(s):** [8a: Making the decision between management or IC Leadership](/notes/8a/);

--- a/src/content/notes/10a.md
+++ b/src/content/notes/10a.md
@@ -9,8 +9,6 @@ Growing in seniority requires more autonomous work. One needs to be able to work
 
 ---
 
-- **Previous Note:** [10: Individual Contributor or Manager](/notes/10/);
-- **Next Note:** [10b: Doing side projects helps you test your ideas](/notes/10b/);
 - **Related Note(s):**
   - [12: Engineer Autonomy](/notes/12/);
   - [13: Be Kind at Work](/notes/13/);

--- a/src/content/notes/10b.md
+++ b/src/content/notes/10b.md
@@ -9,6 +9,4 @@ If you have the energy, do side projects where you can test what you've learned 
 
 ---
 
-- **Previous Note:** [10a: Growing in IC track in Engineering](/notes/10a/);
-- **Next Note:** [11: How to move to the next level](/notes/11/);
 - **Source(s):** [Software World Podcast #9: Engineering Career Path - Tobias Bales](https://candost.substack.com/p/9-engineering-career-path);

--- a/src/content/notes/11.md
+++ b/src/content/notes/11.md
@@ -12,6 +12,3 @@ updateDate: 2022-10-31
 Look at the defined career path in your company. If you don't have one, ask your manager about the expectations. List them down and learn what moving to the next level requires. Then focus on achieving them one by one. While doing this, write down all the things you're doing on the way.
 
 ---
-
-- **Previous Note:** [10b: Doing side projects helps you test your ideas](/notes/10b/);
-- **Next Note:** [12: Engineer Autonomy](/notes/12/);

--- a/src/content/notes/12.md
+++ b/src/content/notes/12.md
@@ -12,5 +12,3 @@ The senior and above levels are more autonomous than juniors or lower levels. Pr
 
 ---
 
-- **Previous Note:** [11: How to move to the next level](/notes/11/);
-- **Next Note:** [12a: Making decisions based on three groups](/notes/12a/);

--- a/src/content/notes/12a.md
+++ b/src/content/notes/12a.md
@@ -11,8 +11,6 @@ When an engineer [gains](/notes/10a/) more autonomy, their decisions have a grea
 
 ---
 
-- **Previous Note:** [12: Engineer Autonomy](/notes/12/);
-- **Next Note:** [13: Be Kind at Work](/notes/13/);
 - **Related Note(s):**
   - [10a: Growing in IC track in Engineering](/notes/10a/);
   - [23: The First Question of Feedback Discussions](/notes/23/);

--- a/src/content/notes/13.md
+++ b/src/content/notes/13.md
@@ -11,6 +11,4 @@ Be kind. If you're working with juniors, they can make mistakes, but they are st
 
 ---
 
-- **Previous Note:** [12a: Making decisions based on three groups](/notes/12a/);
-- **Next Note:** [14: Experiences are like compound interest on money](/notes/14/);
 - **Source(s):** [Software World with Candost 9](https://candost.substack.com/p/9-engineering-career-path);

--- a/src/content/notes/14.md
+++ b/src/content/notes/14.md
@@ -12,7 +12,5 @@ The effects of our habits multiply over time. Same as habits, in our career, wha
 
 ---
 
-- **Previous Note:** [13: Be Kind at Work](/notes/13/);
-- **Next Note:** [15: What should you do when your manager delegates a task to you](/notes/15/);
 - **Related Note(s):** [10a: Growing in IC track in Engineering](/notes/10a/); [30b1: Immunity to suffering requires healthy doses of pain](/notes/30b1/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/15.md
+++ b/src/content/notes/15.md
@@ -22,8 +22,6 @@ People sometimes don't complain even if the delegation is not clear. It doesn't 
 
 ---
 
-- **Previous Entry:** [14: Experiences are like compound interest on money](/notes/14/);
-- **Next Entry:** [16: Managing Time as a Manager](/notes/16/);
 - **Related Note(s):**
   - [32a: Continually and consistently repeat the message](/notes/32a/);
   - [24b: Specify goals instead of methods or processes](/notes/24b/);

--- a/src/content/notes/16.md
+++ b/src/content/notes/16.md
@@ -11,6 +11,4 @@ When you have time, make sure that others have what they need to do the work. Ca
 
 ---
 
-- **Previous Note:** [15: What should you do when your manager delegates a task to you](/notes/15/);
-- **Next Note:** [16a: The Meetings of a manager](/notes/16a/);
 - **Related Note(s):** [19d: Why can't this be done sooner?](/notes/19d/);

--- a/src/content/notes/16a.md
+++ b/src/content/notes/16a.md
@@ -9,6 +9,6 @@ The meetings are the place where the actual work happens. Don’t think you don�
 
 There is no escape from the meetings in management. Even if the team is remote, you’ll have 1:1s, planning meetings, etc. It’s not avoidable.
 
-- **Previous Note:** [16: Managing Time as a Manager](/notes/16/);
-- **Next Note:** [16b: Clarify the expected outcome and the action it requires in written form to get it out of your mind](/notes/16b/);
+----
+
 - **Related Note(s):** [19d: Why can't this be done sooner?](/notes/19d/);

--- a/src/content/notes/16b.md
+++ b/src/content/notes/16b.md
@@ -19,8 +19,6 @@ When both are written down in tasks, it is usually easy to take care of them. On
 
 ---
 
-- **Previous Note:** [16a: The Meetings of a manager](/notes/16a/);
-- **Next Note:** [16c: Have a single highlight of the day](/notes/16c/)
 - **Related Note(s):**
   - [25: Consistent writing brings success](/notes/25/);
   - [27a: Increasing awareness of the actions and behaviors](/notes/27a/);

--- a/src/content/notes/16c.md
+++ b/src/content/notes/16c.md
@@ -15,8 +15,6 @@ If you realize you can't achieve your highlight of the day, you can still change
 
 ---
 
-- **Previous Note:** [16b: Clarify the expected outcome and the action it requires in written form to get it out of your mind](/notes/16b/);
-- **Next Note:** [17: Public Speaking and Improving Skills](/notes/17/)
 - **Related Note(s):**
   - [25: Consistent writing brings success](/notes/25/);
   - [27: Developing Habits](/notes/27/);

--- a/src/content/notes/17.md
+++ b/src/content/notes/17.md
@@ -13,8 +13,6 @@ If the talk is online, they should write to the chat so that there is an engagem
 
 ---
 
-- **Previous Note:** [16c: Have a single highlight of the day](/notes/16c/);
-- **Next Note:** [17a: Choosing a talk topic is art](/notes/17a/);
 - **Related Note(s):**
   - [20a: Thinking out loud](/notes/20a/);
   - [17b: Increasing Public Speaking Skills](/notes/17b/);

--- a/src/content/notes/17a.md
+++ b/src/content/notes/17a.md
@@ -11,6 +11,4 @@ Choosing a talk topic is art. You need to take a look at the roots of a challeng
 
 ---
 
-- **Previous Note:** [17: Public Speaking and Improving Skills](/notes/17/);
-- **Next Note:** [17b: Increasing Public Speaking Skills](/notes/17b/);
 - **Source(s):** Demystifying Public Speaking by Lara Hogan

--- a/src/content/notes/17b.md
+++ b/src/content/notes/17b.md
@@ -11,8 +11,6 @@ Flip your fear and anxiety about public speaking to "deeply caring about the top
 
 ---
 
-- **Previous Note:** [17a: Choosing a talk topic is art](/notes/17a/);
-- **Next Note:** [17c: Do whatever works for you in your public speaking](/notes/17c/);
 - **Related Note(s):**
   - [25: Consistent writing brings success](/notes/25/);
   - [39: Increasing Quality of Systems](/notes/39/);

--- a/src/content/notes/17c.md
+++ b/src/content/notes/17c.md
@@ -11,6 +11,4 @@ date: 2021-11-28
 
 ---
 
-- **Previous Note:** [17b: Increasing Public Speaking Skills](/notes/17b/);
-- **Next Note:** [17d: Focus on only one improvement in every practice run](/notes/17d/);
 - **Source(s):** Demystifying Public Speaking by Lara Hogan

--- a/src/content/notes/17d.md
+++ b/src/content/notes/17d.md
@@ -15,6 +15,4 @@ Learn how to cover screw-ups one by one.
 
 ---
 
-- **Previous Note:** [17c: Do whatever works for you in your public speaking](/notes/17c/);
-- **Next Note:** [17e: Transform your nervousness into mindfulness in public speaking](/notes/17e/);
 - **Source(s):** Demystifying Public Speaking by Lara Hogan

--- a/src/content/notes/17e.md
+++ b/src/content/notes/17e.md
@@ -11,8 +11,6 @@ Transform nervous thinking to mindful thinking in public speaking. Instead of sa
 
 ---
 
-- **Previous Note:** [17d: Focus on only one improvement in every practice run](/notes/17d/);
-- **Next Note:** [17f: Make key takeaways clear on your talk](/notes/17f/);
 - **Related Note(s):**
   - [7: Confident Humility](/notes/7/);
   - [27a: Increasing awareness of the actions and behaviors](/notes/27a/);

--- a/src/content/notes/17f.md
+++ b/src/content/notes/17f.md
@@ -11,6 +11,4 @@ Choose the key takeaways so that an attendee of your talk can directly apply the
 
 ---
 
-- **Previous Note:** [17e: Transform your nervousness into mindfulness](/notes/17e/);
-- **Next Note:** [17g: Prepare and ask questions to create engagement](/notes/17g/);
 - **Source(s):** Demystifying Public Speaking by Lara Hogan

--- a/src/content/notes/17g.md
+++ b/src/content/notes/17g.md
@@ -11,6 +11,4 @@ Ask questions to the audience to create engagement. Put yourself into the audien
 
 ---
 
-- **Previous Note**: [17f: Make key takeaways clear on your talk](/notes/17f/);
-- **Next Note:** [17h: Choosing a topic for content and public speaking](/notes/17h/);
 - **Source(s):** Demystifying Public Speaking by Lara Hogan

--- a/src/content/notes/17h.md
+++ b/src/content/notes/17h.md
@@ -11,8 +11,6 @@ Don't throw away 101 talks. People are more engaged in them. More people don't k
 
 ---
 
-- **Previous Note:** [17g: Prepare and ask questions to create engagement](/notes/17g/);
-- **Next Note:** [17i: How to Understand The Public Talk Feedback You Get](/notes/17i/);
 - **Related Note(s):**
   - [17a: Choosing a talk topic is art](/notes/17a/);
   - [2a: Take breaks to write better](/notes/2a/);

--- a/src/content/notes/17i.md
+++ b/src/content/notes/17i.md
@@ -18,8 +18,6 @@ Always look for Diamonds♦️ and Spades ♠️.
 
 ---
 
-- **Previous Note:** [17h: Choosing a topic for content and public speaking](/notes/17h/);
-- **Next Note:** [18: Inform viewers about questions](/notes/18/);
 - **Related Note(s):**
   - [30c: Choose good values and good metrics in life](/notes/30c/);
   - [44c: Confrontation brings honesty](/notes/44c/);

--- a/src/content/notes/18.md
+++ b/src/content/notes/18.md
@@ -11,6 +11,4 @@ Tell in the beginning that you expect your audience to write something in the ch
 
 ---
 
-- **Previous Note:** [17i: How to Understand The Public Talk Feedback You Get](/notes/17i/);
-- **Next Note:** [19: Decision-Making Strategies](/notes/19/);
 - **Source(s):** A colleague at my previous workplace

--- a/src/content/notes/19.md
+++ b/src/content/notes/19.md
@@ -12,8 +12,6 @@ Justifying the decisions is a complicated process. When we make any decision, th
 
 ---
 
-- **Previous Note:** [18: Inform viewers about questions](/notes/18/);
-- **Next Note:** [19a: Knowns and Unknowns](/notes/19a/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [3a: Team Decision Deployment Strategies](/notes/3a/);

--- a/src/content/notes/19a.md
+++ b/src/content/notes/19a.md
@@ -15,8 +15,6 @@ We should not only be careful but also consider many different perspectives and 
 
 ---
 
-- **Previous Note:** [19: Decision-Making Strategies](/notes/19/);
-- **Next Note:** [19a1: Choosing the old technology](/notes/19a1/);
 - **Related Note(s):** We can find out some unknowns with collaboration.
   - [20: Influencing Others](/notes/20/);
   - [22: Cross-Cultural Communication](/notes/22/);

--- a/src/content/notes/19a1.md
+++ b/src/content/notes/19a1.md
@@ -13,6 +13,4 @@ When technology is boring, it has its standards set. We not only know how to use
 
 ---
 
-- **Previous Note:** [19a: Knowns and Unknowns](/notes/19a/);
-- **Next Note:** [19a2: The process of choosing a new technology](/notes/19a2/);
 - **Source:** [Choose Boring Technology](https://mcfunley.com/choose-boring-technology);

--- a/src/content/notes/19a2.md
+++ b/src/content/notes/19a2.md
@@ -15,7 +15,5 @@ We need to set clear expectations when you want to migrate old technology to the
 
 ---
 
-- **Previous Note:** [19a1: Choosing the old technology](/notes/19a1/);
-- **Next Note:** [19b: Consent-Based Decision Making](/notes/19b/);
 - **Related Note(s):** [How to Stop Endless Discussions](/how-to-stop-endless-discussions/);
 - **Source(s):** [Choose Boring Technology](https://mcfunley.com/choose-boring-technology);

--- a/src/content/notes/19b.md
+++ b/src/content/notes/19b.md
@@ -12,8 +12,6 @@ You have to trust in task-based, low-level communication about why and egalitari
 
 ---
 
-- **Previous Note:** [19a2: The process of choosing a new technology](/notes/19a2/);
-- **Next Note:** [19c: How to move faster in organizations](/notes/19c/);
 - **Related Note(s):**
   - [32: Communicating Decisions in Organizations](/notes/32/);
   - [24b: Specify goals instead of methods or processes](/notes/24b/);

--- a/src/content/notes/19c.md
+++ b/src/content/notes/19c.md
@@ -12,8 +12,6 @@ Businesses work with making decisions and executing the decisions. To move faste
 
 ---
 
-- **Previous Note:** [19b: Consent-Based Decision Making](/notes/19b/);
-- **Next Note:** [19d: Why can't this be done sooner?](/notes/19d/);
 - **Related Note(s):**
   - [29: Uncertainty is needed to stay open-minded](/notes/29/);
 - **Source(s):** [Speed As a Habit by David Girouard on FirstRound Magazine](https://review.firstround.com/speed-as-a-habit);

--- a/src/content/notes/19d.md
+++ b/src/content/notes/19d.md
@@ -11,7 +11,6 @@ Good decisions consist of gathering input and pushing toward it. Ask, "Why can't
 
 ---
 
-- **Next Note:** [19e: How to make faster decisions by validating objections?](/notes/19e/);
 - **Related Note(s):**
   - [24: Strong teams are motivated by goals](/notes/24/);
   - [26: The Cost of Software Deployment and Continuous Delivery](/notes/26/);

--- a/src/content/notes/19e.md
+++ b/src/content/notes/19e.md
@@ -21,7 +21,6 @@ Whenever you hear an objection, ask three questions in order.
 
 ---
 
-- **Next Note:** [19f: Approaches to Decision-Making Styles](/notes/19f/);
 - **Related Note(s):**
   - [37: Setting Organizational Goals and Processes](/notes/37/);
   - [32: Communicating Decisions in Organizations](/notes/32/);

--- a/src/content/notes/19f.md
+++ b/src/content/notes/19f.md
@@ -22,8 +22,6 @@ There are three categories or approaches to decision-making styles in the world 
 
 ---
 
-- **Previous Note:** [19e: How to make faster decisions by validating objections?](/notes/19e/);
-- **Next Note:** [20: Influencing Others](/notes/20/);
 - **Related Note(s):**
   - [12: Engineer Autonomy](/notes/12/);
   - [14: Experiences are like compound interest on money](/notes/14/);

--- a/src/content/notes/1a.md
+++ b/src/content/notes/1a.md
@@ -26,8 +26,6 @@ Edit and proofread the document and share. Go to the next topic.
 
 ---
 
-- **Previous Note:** [1: Why do we bother to write?](/notes/1/);
-- **Next Note:** [1b: Writing by Hand](/notes/1b/);
 - **Related Posts:**
   - [How to Stop Endless Discussions](/how-to-stop-endless-discussions/);
   - [Why is Writing Important?](/why-is-writing-important/);

--- a/src/content/notes/1b.md
+++ b/src/content/notes/1b.md
@@ -12,6 +12,4 @@ Writing by hand is more effective than writing on a computer or other electronic
 
 ---
 
-- **Previous Note:** [1a: How Zettelkasten Method Works](/notes/1a/);
-- **Next Note:** [1c: How to Take Literature Notes](/notes/1c/);
 - **Source(s):** How to Take Smart Notes Book

--- a/src/content/notes/1c.md
+++ b/src/content/notes/1c.md
@@ -20,6 +20,4 @@ The goal is understanding the text and preparing to transfer ideas into the cont
 
 ---
 
-- **Previous Note:** [1b: Writing by Hand](/notes/1b/);
-- **Next Note:** [1d: Adding a New Note To Slip-Box](/notes/1d/);
 - **Source(s):** How to Take Smart Notes Book

--- a/src/content/notes/1d.md
+++ b/src/content/notes/1d.md
@@ -14,6 +14,4 @@ Instead of directly relating the note to something, we are nudged not to fit the
 
 ---
 
-- **Previous Note:** [1c: How to Take Literature Notes](/notes/1c/);
-- **Next Note:** [1e: Contradictions in ideas within the thought line](/notes/1e/);
 - **Source(s):** How to Take Smart Notes Book

--- a/src/content/notes/1e.md
+++ b/src/content/notes/1e.md
@@ -12,6 +12,4 @@ Contradictions within the slip-box can be discussed further in the thought line.
 
 ---
 
-- **Previous Note:** [1d: Adding a New Note To Slip-Box](/notes/1d/);
-- **Next Note:** [1f: Elaboration on An Idea](/notes/1f/);
 - **Source(s):** How to Take Smart Notes Book

--- a/src/content/notes/1f.md
+++ b/src/content/notes/1f.md
@@ -12,6 +12,4 @@ The most successful learning method is the elaboration of what we've learned. Wh
 
 ---
 
-- **Previous Note:** [1e: Contradictions in ideas within the thought line](/notes/1e/);
-- **Next Note:** [1g: Winners and Losers Share The Same Goals](/notes/1g/);
 - **Source(s):** How to Take Smart Notes Book

--- a/src/content/notes/1g.md
+++ b/src/content/notes/1g.md
@@ -10,7 +10,5 @@ Achieving goals are only for the moment. Winners focus on the systems and how to
 
 ---
 
-- **Previous Note:** [1f: Elaboration on An Idea](/notes/1f/);
-- **Next Note:** [1h: Continuous Improvement Means Changing The System; Not The Goal](/notes/1h/);
 - **Source(s):** Atomic Habits
 - **Resourced:** [Growth with Systematic Bliss](/growth-with-systematic-bliss/);

--- a/src/content/notes/1h.md
+++ b/src/content/notes/1h.md
@@ -12,6 +12,4 @@ One of the most common systems in the software industry is continuous improvemen
 
 ---
 
-- **Previous Note:** [1g: Winners and Losers Share The Same Goal](/notes/1g/);
-- **Next Note:** [1i: Embrace & Love Boredom](/notes/1i/);
 - **Source(s):** Atomic Habits

--- a/src/content/notes/1i.md
+++ b/src/content/notes/1i.md
@@ -14,6 +14,4 @@ This sentence has many aspects. Producing something valuable and being a creator
 
 ---
 
-- **Previous Note:** [1h: Continuous Improvement Means Changing The System; Not The Goal](/notes/1h/);
-- **Next Note:** [1j: No happiness without suffering](/notes/1j/);
 - **Source(s):** Atomic Habits

--- a/src/content/notes/1j.md
+++ b/src/content/notes/1j.md
@@ -9,6 +9,4 @@ There is no happiness without suffering. Also, suffering is not suffering while 
 
 ---
 
-- **Previous Note:** [1i: Embrace & Love Boredom](/notes/1i/);
-- **Next Note:** [2: How to Improve Writing](/notes/2/);
 - **Source(s):** [The Subtle Art of Not Giving A Fuck](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);

--- a/src/content/notes/2.md
+++ b/src/content/notes/2.md
@@ -13,6 +13,4 @@ When we rewrite the text we have written, we learn about the parts we didn't kno
 
 ---
 
-- **Previous Note:** [1j: No happiness without suffering](/notes/1j/);
-- **Next Note:** [2a: Take breaks to write better](/notes/2a/);
 - **Source(s):** Bird by Bird by Anne Lamott

--- a/src/content/notes/20.md
+++ b/src/content/notes/20.md
@@ -12,8 +12,6 @@ When we share our thinking with someone early enough, we can generate more ideas
 
 ---
 
-- **Previous Note:** [19f: Approaches to Decision-Making Styles](/notes/19f/);
-- **Next Note:** [20a: Thinking out loud](/notes/20a/);
 - **Related Note(s):**
   - [26: The Cost of Software Deployment and Continuous Delivery](/notes/26/);
   - [32: Communicating Decisions in Organizations](/notes/32/);

--- a/src/content/notes/20a.md
+++ b/src/content/notes/20a.md
@@ -11,6 +11,4 @@ The same might work with saying "let me play devil's advocate" from [The Culture
 
 ---
 
-- **Previous Note:** [20: Influencing Others](/notes/20/);
-- **Next Note:** [20b: Sharing knowledge is not a noise](/notes/20b/);
 - **Source(s):** [Turn The Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/20b.md
+++ b/src/content/notes/20b.md
@@ -9,6 +9,4 @@ Knowledge sharing might seem like a lot of noise. However, when the knowledge is
 
 ---
 
-- **Previous Note:** [20a: Thinking out loud](/notes/20a/);
-- **Next Note:** [20c: Share pros and cons in announcements](/notes/20c/);
 - **Source(s):** [Turn The Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/20c.md
+++ b/src/content/notes/20c.md
@@ -13,8 +13,6 @@ Sometimes leadership introduce something and don't explain what they had conside
 
 ---
 
-- **Previous Note:** [20d: Click and Run](/notes/20d/);
-- **Next Note:** [21: Efficient Code Review Process](/notes/21/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [6: Being a boss who cares personally](/notes/6/);

--- a/src/content/notes/20d.md
+++ b/src/content/notes/20d.md
@@ -11,8 +11,6 @@ In small favors that are often invisible, we give a lot of automatic responses. 
 
 ---
 
-- **Previous Note:** [20c: Share pros and cons in announcements](/notes/20c/);
-- **Next Note:** [20e: Perceptual Contrast](/notes/20e/);
 - **Related Note(s):**
   - [30: Scientific Thinking and Fact-Checking for A Better Life](/notes/30/);
 - **Source(s):** Influence by Roberd B. Cialdini

--- a/src/content/notes/20e.md
+++ b/src/content/notes/20e.md
@@ -12,8 +12,6 @@ If you would like to use the perceptual contrast principle in practice while try
 
 ---
 
-- **Previous Note:** [20d: Click and Run](/notes/20d/);
-- **Next Note:** [20f: How being liked helps you to get your job done](/notes/20f/);
 - **Related Note(s):**
   - [19f: Three Approaches to Decision-Making Styles](/notes/19f/);
   - [32: Communicating Decisions in Organizations](/notes/32/);

--- a/src/content/notes/20f.md
+++ b/src/content/notes/20f.md
@@ -12,8 +12,6 @@ The same is with your team as a leader, the more liked you are, the more they ta
 
 ---
 
-- **Previous Note:** [20e: Perceptual Contrast](/notes/20e/);
-- **Next Note:** [20g: Increase your physical attractiveness](/notes/20g/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [7: Confident Humility](/notes/7/);

--- a/src/content/notes/20g.md
+++ b/src/content/notes/20g.md
@@ -11,8 +11,6 @@ Increase your physical attractiveness when you work. People give more social adv
 
 ---
 
-- **Previous Note:** [20f: How being liked helps you to get your job done](/notes/20f/);
-- **Next Note:** [20h: Find similarities to increase likeness](/notes/20h/);
 - **Related Note(s):**
   - [11: How to move to the next level](/notes/11/);
   - [17: Public Speaking and Improving Skills](/notes/17/);

--- a/src/content/notes/20h.md
+++ b/src/content/notes/20h.md
@@ -13,8 +13,6 @@ Creating familiarity and similarity brings people closer to you. Regardless of w
 
 ---
 
-- **Previous Note:** [20g: Increase your physical attractiveness](/notes/20g/);
-- **Next Note:** [20i: Compliments increase liking](/notes/20i/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [7: Confident Humility](/notes/7/);

--- a/src/content/notes/20i.md
+++ b/src/content/notes/20i.md
@@ -12,8 +12,6 @@ But be careful when you give compliment to your boss. Try to do it via third per
 
 ---
 
-- **Previous Note:** [20h: Increase your physical attractiveness](/notes/20h/);
-- **Next Note:** [21: Efficient Code Review Process](/notes/21/);
 - **Related Note(s):**
   - [4e: Compliment to improve occasional good behavior](/notes/4e/);
   - [13: Be Kind at Work](/notes/13/);

--- a/src/content/notes/21.md
+++ b/src/content/notes/21.md
@@ -75,8 +75,6 @@ Faster and better onboarding. We will get feedback from the people who are curre
 
 ---
 
-- **Previous Note:** [20i: Compliments increase likeness](/notes/20i/);
-- **Next Note:** [21a: Why should we do a code review?](/notes/21a/);
 - **Related Note(s):**
   - [13: Be Kind at Work](/notes/13/);
   - [19a: Knowns and Unknowns](/notes/19a/);

--- a/src/content/notes/21a.md
+++ b/src/content/notes/21a.md
@@ -9,6 +9,4 @@ When we're onboarding, we often don't know the domain and the system. On a perso
 
 ---
 
-- **Previous Note:** [21: Efficient Code Review Process](/notes/21/);
-- **Next Note:** [21b: Four stages of the best code review process](/notes/21b/);
 - **Related Note(s):** [19a: Knowns and Unknowns](/notes/19a/);

--- a/src/content/notes/21b.md
+++ b/src/content/notes/21b.md
@@ -9,6 +9,4 @@ The most convincing code review happens in four steps. First, make it obvious: e
 
 ---
 
-- **Previous Note:** [21a: Why should we do a code review?](/notes/21a/);
-- **Next Note:** [22: Cross-Cultural Communication](/notes/22/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/22.md
+++ b/src/content/notes/22.md
@@ -13,7 +13,6 @@ Two high-context cultures: Both high-context cultures try to read the air from t
 
 ---
 
-- **Next Note:** [22a: Don't assume while working with people from various cultures](/notes/22a/);
 - **Related Note(s):**
   - [4a: On Being Curious](/notes/4a/);
   - [20a: Thinking out loud](/notes/20a/);

--- a/src/content/notes/22a.md
+++ b/src/content/notes/22a.md
@@ -13,6 +13,3 @@ You shouldn't assume things. For example, when you are not sure about someone's 
 Having a diverse workforce is a crucial step for many companies. Leaders in these companies need to build trust with many different cultures. That's why leaders have to learn when to ask explicitly and how to read between lines. As a practice, ask yourself "is this knowledge come from my assumptions, or did I ask explicitly about it, or did I hear them talking about it before?"
 
 ---
-
-- **Previous Note:** [22: Cross-Cultural Communication](/notes/22/);
-- **Next Note:** [23: The First Question of Feedback Discussions](/notes/23/);

--- a/src/content/notes/23.md
+++ b/src/content/notes/23.md
@@ -25,6 +25,4 @@ Always ask in which form (written or verbal) they would like to receive _any_ 
 
 ---
 
-- **Previous Note:** [22a: Don't assume while working with people from various cultures](/notes/22a/);
-- **Next Note:** [23a: Give positive feedback at the moment of action](/notes/23a/);
 - **Source(s):** [The Culture Map by Erin Meyer](/books/high-productivity-and-clear-communication-in-different-cultures/);

--- a/src/content/notes/23a.md
+++ b/src/content/notes/23a.md
@@ -13,6 +13,4 @@ The feedback has its meaning when it's timely. Positive feedback usually feels l
 
 ---
 
-- **Previous Note:** [23: The First Question of Feedback Discussions](/notes/23/);
-- **Next Note:** [23b: Authority has no impact when action on feedback](/notes/23b/);
 - **Source(s):** [Turn The Ship Around by David Marquet](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/23b.md
+++ b/src/content/notes/23b.md
@@ -13,6 +13,4 @@ When an authoritative figure (like a CEO or manager at work) gives feedback, the
 
 ---
 
-- **Previous Note**: [23a: Give positive feedback at the moment of action](/notes/23a/);
-- **Next Note:** [23b1: Be careful with obnoxious aggression](/notes/23b1/);
 - **Source(s):** Thanks For The Feedback by Douglas Stone & Sheila Heen

--- a/src/content/notes/23b1.md
+++ b/src/content/notes/23b1.md
@@ -15,6 +15,4 @@ Obnoxious Aggression also occurs in praise. If you give praise without personall
 
 ---
 
-- **Previous Note**: [23b: Authority has no impact when action on feedback](/notes/23b/);
-- **Next Note:** [23c: How to give positive feedback?](/notes/23c/);
 - **Source(s):** Radical Candor by Kim Scott

--- a/src/content/notes/23c.md
+++ b/src/content/notes/23c.md
@@ -17,6 +17,4 @@ Last but not least, the feedback has to be authentic. Be mindful and selective. 
 
 ---
 
-- **Previous Note:** [23b1: Be careful with obnoxious aggression](/notes/23b1/);
-- **Next Note:** [23c1: What is Manipulative Insincerity?](/notes/23c1/);
 - **Source(s):** Thanks for The Feedback by Douglas Stone & Sheila Heen

--- a/src/content/notes/23c1.md
+++ b/src/content/notes/23c1.md
@@ -12,6 +12,4 @@ In manipulative insincerity, you give feedback to others without personally cari
 
 ---
 
-- **Previous Note:** [23c: How to give positive feedback?](/notes/23c/);
-- **Next Note:** [23d: Don't give feedback for the sake of giving feedback](/notes/23d/);
 - **Source(s):** Radical Candor by Kim Scott

--- a/src/content/notes/23d.md
+++ b/src/content/notes/23d.md
@@ -12,6 +12,4 @@ When we give feedback to each other, we sometimes get stuck in the feedback. I o
 
 ---
 
-- **Previous Note:** [23c1: What is Manipulative Insincerity?](/notes/23c1/);
-- **Next Note:** [23e: How to show a blame absorber other factors' impact on the problem](/notes/23e/);
 - **Source(s):** Thanks for The Feedback by Douglas Stone & Sheila Heen

--- a/src/content/notes/23e.md
+++ b/src/content/notes/23e.md
@@ -16,8 +16,6 @@ While explaining, don't load all responsibility into yourself or the system. Let
 
 ---
 
-- **Previous Note:** [23d: Don't give feedback for the sake of giving feedback](/notes/23d/);
-- **Next Note:** [23f: Just say what you are going to say while giving a damn.](/notes/23f/);
 - **Related Note(s):**
   - [6: Being a boss who cares personally](/notes/6/);
   - [3c: Giving Ownership to People](/notes/3c/);

--- a/src/content/notes/23f.md
+++ b/src/content/notes/23f.md
@@ -15,8 +15,6 @@ In the end, "If you are holding an authoritative position, just say what you are
 
 ---
 
-- **Previous Note:** [23e: How to show a blame absorber other factors' impact on the problem](/notes/23e/);
-- **Next Note:** [23g: How to have better performance review meetings as a leader](/notes/23g/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [3b1: Building Trust as a New Engineering Manager](/notes/3b1/);

--- a/src/content/notes/23g.md
+++ b/src/content/notes/23g.md
@@ -13,8 +13,6 @@ Regular performance reviews are evaluating meetings. We evaluate the previous ye
 
 ---
 
-- **Previous Note:** [23f: Just say what you are going to say while giving a damn](/notes/23f/);
-- **Next Note:** [23h: Feedback is mutual](/notes/23h/);
 - **Related Note(s):**
   - [27a: Increasing awareness of the actions and behaviors](/notes/27a/);
   - [35: Protective Leadership](/notes/35/);

--- a/src/content/notes/23h.md
+++ b/src/content/notes/23h.md
@@ -12,8 +12,6 @@ Take the first step to share feedback. [The rule of reciprocation](/notes/30d1/)
 
 ---
 
-- **Previous Note:** [23g: How to have better performance review meetings as a leader](/notes/23g/);
-- **Next Note:** [24: Strong teams are motivated by goals](/notes/24/);
 - **Related Note(s):**
   - [30d1: The Rule of Reciprocation](/notes/30d1/);
   - [13: Be Kind At Work](/notes/13/);

--- a/src/content/notes/23i.md
+++ b/src/content/notes/23i.md
@@ -1,0 +1,17 @@
+---
+zettelId: "23i"
+title: "Giving feedback with a coaching mindset"
+tags:
+  - management-handbook_how-to-give-feedback
+  - feedback-handbook_giving
+  - management-handbook_coaching-others
+updateDate: 2024-11-22T00:00:00.007Z
+date: 2024-11-22T00:00:00.007Z
+---
+
+Take the first step to share feedback. [The rule of reciprocation](/notes/30d1/) can play a big role when you want to get feedback, too. Especially for the positive feedback, take the extra time to provide it in the most visible way. This favor will get its return when you need feedback, too. While the other person thanks for the feedback, don’t just discard it by saying, “You’re welcome” or “No problem at all,” use the opportunity to enforce the rule of reciprocation by saying, “If our positions are reversed, I’m sure you’d do the same.”
+When [giving feedback](21.md) to direct reports or mentees, [ask](6.md) what they could have done differently in a given situation. Ask them about [what they learned](33a.md) instead of starting with giving feedback.
+
+This will allow them to think independently before receiving any suggestions and will help them learn more than they would when hearing someone else’s feedback.
+
+---

--- a/src/content/notes/23i.md
+++ b/src/content/notes/23i.md
@@ -10,7 +10,7 @@ date: 2024-11-22T00:00:00.007Z
 ---
 
 Take the first step to share feedback. [The rule of reciprocation](/notes/30d1/) can play a big role when you want to get feedback, too. Especially for the positive feedback, take the extra time to provide it in the most visible way. This favor will get its return when you need feedback, too. While the other person thanks for the feedback, don’t just discard it by saying, “You’re welcome” or “No problem at all,” use the opportunity to enforce the rule of reciprocation by saying, “If our positions are reversed, I’m sure you’d do the same.”
-When [giving feedback](21.md) to direct reports or mentees, [ask](6.md) what they could have done differently in a given situation. Ask them about [what they learned](33a.md) instead of starting with giving feedback.
+When [giving feedback](/notes/21/) to direct reports or mentees, [ask](/notes/6/) what they could have done differently in a given situation. Ask them about [what they learned](/notes/33a/) instead of starting with giving feedback.
 
 This will allow them to think independently before receiving any suggestions and will help them learn more than they would when hearing someone else’s feedback.
 

--- a/src/content/notes/24.md
+++ b/src/content/notes/24.md
@@ -13,8 +13,6 @@ People have different motivation drivers. However, when we form teams, they are 
 
 ---
 
-- **Previous Note:** [23h: Feedback is mutual](/notes/23h/);
-- **Next Note:** [24a: Creating goals when you join a new team](/notes/24a/);
 - **Related Note(s):**
   - [32a: Continually and consistently repeat the message](/notes/32a/);
   - [35: Protective Leadership](/notes/35/);

--- a/src/content/notes/24a.md
+++ b/src/content/notes/24a.md
@@ -13,7 +13,5 @@ If you are joining a new team, one of the first things you should do is learn th
 
 ---
 
-- **Previous Note:** [24: Strong teams are motivated by goals](/notes/24/);
-- **Next Note:** [24b: Specify goals, not methods](/notes/24b/)
 - **Related Note(s):** [3b: Joining A Team As A New Manager](/notes/3b/);
 - **Source(s):** Introduction to OKRs by Christina Wodtke

--- a/src/content/notes/24b.md
+++ b/src/content/notes/24b.md
@@ -10,6 +10,4 @@ Specifying goals instead of methods creates confidence. When people try to focus
 
 ---
 
-- **Previous Note:** [24a: Creating goals when you join a new team](/notes/24a/);
-- **Next Note:** [24b1: Begin with The End in Mind](/notes/24b1/);
 - **Source(s):** [Turn The Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/24b1.md
+++ b/src/content/notes/24b1.md
@@ -10,8 +10,6 @@ Writing up evaluations of 1, 3, and 5 years later and thinking ahead clears the 
 
 ---
 
-- **Previous Note:** [24b: Specify goals, not methods](/notes/24b/);
-- **Next Note:** [24c: People need clarity, not motivation](/notes/24c/);
 - **Related Note(s):**
   - [25a: You get what you repeat](/notes/25a/);
   - [1h: Continuous Improvement Means Changing The System](/notes/1h/);

--- a/src/content/notes/24c.md
+++ b/src/content/notes/24c.md
@@ -9,7 +9,5 @@ Does [this](/notes/25b/) work with tasks at work, too? When people say that they
 
 ---
 
-- **Previous Note:** [24b1: Begin with The End in Mind](/notes/24b1/);
-- **Next Note:** [24d: Strong product teams solve customer problems, instead of output](/notes/24d/);
 - **Related Note(s):** [25b: Making the habit obvious help to break waiting for motivation](/notes/25b/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/24d.md
+++ b/src/content/notes/24d.md
@@ -12,6 +12,4 @@ The strategy serves customers (not businesses) but works for the company.
 
 ---
 
-- **Previous Note:** [24c: People need clarity, not motivation](/notes/24c/);
-- **Next Note:** [24e: Recognize but don't promote all of your employees](/notes/24e/);
 - **Source(s):** Empowered by Marty Cagan & Chris Jones

--- a/src/content/notes/24e.md
+++ b/src/content/notes/24e.md
@@ -15,8 +15,6 @@ Finding opportunities for these people is the delicate and difficult part of bei
 
 ---
 
-- **Previous Note:** [24d: Strong product teams solve customer problems, instead of output](/notes/24d/);
-- **Next Note:** [25: Consistent writing brings success](/notes/25/);
 - **Related Note(s):**
   - [5: Managing Promotions](/notes/5/);
   - [3b5: Asking Questions to Build Trust with A Direct Report](/notes/3b5/);

--- a/src/content/notes/25.md
+++ b/src/content/notes/25.md
@@ -15,8 +15,6 @@ Being a consistent writer is one of the underrated and underestimated skills. If
 
 ---
 
-- **Previous Note:** [24e: Recognize but don't promote all of your employees](/notes/24e/);
-- **Next Note:** [25a: You get what you repeat](/notes/25a/);
 - **Connectioins:**
   - [1: Why do we bother to write?](/notes/1/);
   - Starting to write in a big chunk or start small: [26a: The Bigger Batch-Size Deployment's Impact on People](/notes/26a/);

--- a/src/content/notes/25a.md
+++ b/src/content/notes/25a.md
@@ -11,7 +11,5 @@ Big-win moments are the results of previous actions. These previous actions can 
 
 ---
 
-- **Previous Note:** [25: Consistent writing brings success](/notes/25/);
-- **Next Note:** [25b: Making the habit obvious help to break waiting for motivation](/notes/25b/);
 - **Related Note(s):** [24c: People need clarity, not motivation](/notes/24c/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/25b.md
+++ b/src/content/notes/25b.md
@@ -9,7 +9,5 @@ When we fail to form a new habit or get rid of a bad one, we focus on having mot
 
 ---
 
-- **Previous Note:** [25a: You get what you repeat](/notes/25a/);
-- **Next Note:** [25c: Don't slip away twice](/notes/25c/);
 - **Related Note(s):** [24c: People need clarity, not motivation](/notes/24c/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/25c.md
+++ b/src/content/notes/25c.md
@@ -13,6 +13,4 @@ updateDate: 2023-09-20
 
 ---
 
-- **Previous Note:** [25b: Making the habit obvious helps not to wait for motivation](/notes/25b/);
-- **Next Note:** [25d: Commitment gives you freedom](/notes/25d/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/25d.md
+++ b/src/content/notes/25d.md
@@ -16,6 +16,4 @@ Committing is saying no to many other things. It frees us, reduces our stress, a
 
 ---
 
-- **Previous Entry:** [25c: Don't slip away twice](/notes/25c/);
-- **Next Entry:** [26: The Cost of Software Deployment and Continuous Delivery](/notes/26/);
 - **Sources:** [The Subtle Art of Not Giving A Fuck by Mark Manson](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);

--- a/src/content/notes/26.md
+++ b/src/content/notes/26.md
@@ -15,8 +15,6 @@ When the batch size becomes larger, people start multitasking in deployments bec
 
 ---
 
-- **Previous Note:** [25d: Commitment gives you freedom](/notes/25d/);
-- **Next Note:** [26a: The Bigger Batch-Size Deployment's Impact on People](/notes/26a/);
 - **Related Note(s):**
   - [31d: Effectively Learn from mistakes](/notes/31d/);
   - [19c: How to move faster in organizations](/notes/19c/);

--- a/src/content/notes/26a.md
+++ b/src/content/notes/26a.md
@@ -11,6 +11,4 @@ Psychological safety gets lower. Since the changes are significant and the risk 
 
 ---
 
-- **Previous Note:** [26: The Cost of Software Deployment and Continuous Delivery](/notes/26/);
-- **Next Note:** [26b: Bigger Batch Size Deployments lower product feedback cycle](/notes/26b/);
 - **Source(s):** [Small batches for the win-Continuous Delivery](https://www.eferro.net/2021/01/small-batches-for-win-continuous.html);

--- a/src/content/notes/26b.md
+++ b/src/content/notes/26b.md
@@ -9,6 +9,4 @@ Big batch-size deployments lower the feedback cycle. With small batch deployment
 
 ---
 
-- **Previous Note:** [26a: The Bigger Batch-Size Deployment's Impact on People](/notes/26a/);
-- **Next Note:** [26c: Lack of ownership](/notes/26c/);
 - **Source(s):** [Small batches for the win-Continuous Delivery](https://www.eferro.net/2021/01/small-batches-for-win-continuous.html);

--- a/src/content/notes/26c.md
+++ b/src/content/notes/26c.md
@@ -9,6 +9,4 @@ When we have bigger-size deployments, the deployment team might seem like they o
 
 ---
 
-- **Previous Note:** [26b: Bigger Batch Size Deployments lower product feedback cycle](/notes/26b/);
-- **Next Note:** [26d: Software Delivery Batch size vs. Transaction Cost](/notes/26d/);
 - **Source(s):** [Small batches for the win-Continuous Delivery](https://www.eferro.net/2021/01/small-batches-for-win-continuous.html);

--- a/src/content/notes/26d.md
+++ b/src/content/notes/26d.md
@@ -11,7 +11,5 @@ Big batches have other costs, such as the number of people needed to align incre
 
 ---
 
-- **Previous Note:** [26c: Lack of ownership](/notes/26c/);
-- **Next Note:** [27: Developing Habits](/notes/27/);
 - **Related Note(s):** [39: Increasing Quality of Systems](/notes/39/);
 - **Source(s):** [Small batches for the win-Continuous Delivery](https://www.eferro.net/2021/01/small-batches-for-win-continuous.html);

--- a/src/content/notes/27.md
+++ b/src/content/notes/27.md
@@ -12,7 +12,5 @@ Don't act, do it. When you are doing something, don't act like you are doing it.
 
 ---
 
-- **Previous Note:** [26d: Software Delivery Batch Size vs. Transaction Cost](/notes/26d/);
-- **Next Note:** [27a: Increasing awareness of the actions and behaviors](/notes/27a/);
 - **Related Note(s):** [1: Why do we bother to write?](/notes/1/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/27a.md
+++ b/src/content/notes/27a.md
@@ -13,8 +13,6 @@ Naming the actions, especially the ones we do without thinking, increases the co
 
 ---
 
-- **Previous Note:** [27: Developing Habits](/notes/27/);
-- **Next Note:** [27b: How to Learn New Things via Habit Stacking](/notes/27b/);
 - **Related Note(s):**
   - [25b: Making the habit obvious help to break waiting for motivation](/notes/25b/);
   - [27b: How to Learn New Things via Habit Stacking](/notes/27b/);

--- a/src/content/notes/27b.md
+++ b/src/content/notes/27b.md
@@ -10,8 +10,6 @@ Habit stacking is a technique to tie a new habit into an existing one. Old habit
 
 ---
 
-- **Previous Note:** [27a: Increasing awareness of the actions and behaviors](/notes/27a/);
-- **Next Note:** [27b1: Knowledge and beliefs' impact on learning](/notes/27b1/);
 - **Related Note(s):**
   - [39: Increasing Quality of Systems](/notes/39/);
   - [17g: Prepare and ask questions to create engagement](/notes/17g/);

--- a/src/content/notes/27b1.md
+++ b/src/content/notes/27b1.md
@@ -11,8 +11,6 @@ The knowledge we have impacts how we approach things. When we form beliefs, we a
 
 ---
 
-- **Previous Note:** [27b: How to Learn New Things via Habit Stacking](/notes/27b/);
-- **Next Note:** [27c: Environment is more important than we think in building new habits](/notes/27c/);
 - **Related Note(s):**
   - [8: Growing in the Career](/notes/8/);
   - [10a: Growing in IC track in Engineering](/notes/10a/);

--- a/src/content/notes/27c.md
+++ b/src/content/notes/27c.md
@@ -12,6 +12,4 @@ Smokers have many cues around them. They always have a reason to light up a ciga
 
 ---
 
-- **Previous Note:** [27b1: Impact of knowledge and beliefs on learning](/notes/27b1/);
-- **Next Note:** [27d: Self-control and motivation are short-term strategies](/notes/27d/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/27d.md
+++ b/src/content/notes/27d.md
@@ -9,6 +9,4 @@ Reduce cues of bad habits. Increase exposure to good habits and related things b
 
 ---
 
-- **Previous Note:** [27c: Why Environment Matters More Than You Think When Building Habits](/notes/27c/);
-- **Next Note:** [27e: Learn when you reflect: 20/40 Rule](/notes/27e/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/27e.md
+++ b/src/content/notes/27e.md
@@ -9,5 +9,3 @@ Always spend a minimum of 20 minutes before asking for any help. Never spend 40 
 
 ---
 
-- **Previous Note:** [27d: Self-control and motivation are short-term strategies](/notes/27d/);
-- **Next Note:** [27f: Try to keep your learning in "Just Manageable Difficulty."](/notes/27f/);

--- a/src/content/notes/27f.md
+++ b/src/content/notes/27f.md
@@ -9,6 +9,4 @@ If you want to learn something and grow yourself on that topic constantly, you n
 
 ---
 
-- **Previous Note:** [27e: Learn when you reflect: 20/40 Rule](/notes/27e/);
-- **Next Note:** [27f1: Build your skills gradually to climb Mount Everest](/notes/27f1/);
 - **Source(s):** Atomic Habits by James Clear

--- a/src/content/notes/27f1.md
+++ b/src/content/notes/27f1.md
@@ -12,8 +12,6 @@ If you want to climb Mount Everest, you don't start by going there and walking u
 
 ---
 
-- **Previous Note:** [27f: Try to keep your learning in 'Just Manageable Difficulty.'](/notes/27f/);
-- **Next Note:** [28: Mental Health for Professionals](/notes/28/);
 - **Related Note(s):**
   - [2: How to Improve Writing](/notes/2/);
   - [7: Confident Humility](/notes/7/);

--- a/src/content/notes/28.md
+++ b/src/content/notes/28.md
@@ -13,8 +13,6 @@ How we grow up shapes us—all of our thoughts, lifestyle, values, and more. Gro
 
 ---
 
-- **Previous Note:** [27f1: Build your skills gradually to climb Mount Everest](/notes/27f1/);
-- **Next Note:** [29: Uncertainty is needed to stay open-minded](/notes/29/);
 - **Related Note(s):**
   - [8: Growing in the Career](/notes/8/);
   - [27a: Increasing awareness of the actions and behaviors](/notes/27a/);

--- a/src/content/notes/29.md
+++ b/src/content/notes/29.md
@@ -18,7 +18,5 @@ When we put everything in a certain way, there is no joy in it. The joy, learnin
 
 ---
 
-- **Previous Note:** [28: Mental Health for Professionals](/notes/28/);
-- **Next Note:** [29a: Bet on things that won't change](/notes/29a/);
 - **Related Note(s):** [52: Personal Values](/notes/52/);
 - **Source(s):** [The Subtle Art of Not Giving A Fuck by Mark Manson](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);

--- a/src/content/notes/29a.md
+++ b/src/content/notes/29a.md
@@ -16,8 +16,6 @@ Many experts fail to predict the future because many things change constantly. H
 
 ---
 
-- **Previous Note:** [29: Uncertainty is needed to stay open-minded](/notes/29/);
-- **Next Note:** [30: Scientific Thinking and Fact-Checking for A Better Life](/notes/30/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [9c: Simple Ideas Prevent Complicated Problems](/notes/9c/);

--- a/src/content/notes/2a.md
+++ b/src/content/notes/2a.md
@@ -9,8 +9,6 @@ Take breaks while writing. When you write a text and return later, you recognize
 
 ---
 
-- **Previous Note:** [2: How to Improve Writing](/notes/2/);
-- **Next Note:** [2b: How to get rid of distractions in your head while you write](/notes/2b/);
 - **Related Note(s):**
   - [1i: Embrace & Love Boredom](/notes/1i/);
   - [62: Energy Management at Work](/notes/62/);

--- a/src/content/notes/2b.md
+++ b/src/content/notes/2b.md
@@ -9,7 +9,5 @@ Writing is boring. Sometimes, when you start writing, there are many voices and 
 
 ---
 
-- **Previous Note:** [2a: Take breaks to write better](/notes/2a/);
-- **Next Note:** [2c: Write a letter to a friend](/notes/2c/);
 - **Related Note(s):** [1j: No happiness without suffering](/notes/1j/);
 - **Source(s):** Bird by Bird by Anne Lamott

--- a/src/content/notes/2c.md
+++ b/src/content/notes/2c.md
@@ -11,6 +11,4 @@ When you write to a friend, it also includes authenticity—writing to an audien
 
 ---
 
-- **Previous Note:** [2b: How to get rid of distractions in your head while you write](/notes/2b/);
-- **Next Note:** [2d: Leave the Reader with Only One Idea](/notes/2d/);
 - **Source(s):** Bird by Bird by Anne Lamott

--- a/src/content/notes/2d.md
+++ b/src/content/notes/2d.md
@@ -11,7 +11,5 @@ In non-fiction, it's tempting always to fire ideas and arguments to the reader. 
 
 ---
 
-- **Previous Note:** [2c: Write a letter to a friend](/notes/2c/);
-- **Next Note:** [2e: Elements of a Story](/notes/2e/);
 - **Source(s):** On Writing Well by William Zinsser
 - **Resourced:** [What I Learned About Getting Better at Giving Talks and Presentations](/what-i-learned-about-getting-better-at-giving-talks-and-presentations/);

--- a/src/content/notes/2e.md
+++ b/src/content/notes/2e.md
@@ -9,7 +9,5 @@ Every story has elements inside. Some people list fundamental elements of a stor
 
 ---
 
-- **Previous Note:** [2d: Leave the Reader with Only One Idea](/notes/2d/);
-- **Next Note:** [2f: Elaboration on An Idea](/notes/2f/);
 - **Related Note(s):** [2a: Take breaks to write better](/notes/2a/);
 - **Source(s):** Unleash the Power of Storytelling by Rob Biesenbach

--- a/src/content/notes/2f.md
+++ b/src/content/notes/2f.md
@@ -13,7 +13,5 @@ updateDate: 2023-08-13
 
 ---
 
-- **Previous Note:** [2e: Elements of a Story](/notes/2e/);
-- **Next Note:** [3: Being a Team Manager and Manager's Job](/notes/3/);
 - **Source(s):** Unleash the Power of Storytelling by Rob Biesenbach
 - **Resourced:** [Mektup #49: The Craft of Writing Effectively](/newsletter/mektup-49/);

--- a/src/content/notes/3.md
+++ b/src/content/notes/3.md
@@ -18,6 +18,3 @@ There are also unknown unknowns. For instance, introducing new technology to an 
 If you're joining a team, know your unknowns or try to figure them out.
 
 ---
-
-- **Previous Note:** [2f: How to create a story?](/notes/2f/);
-- **Next Note:** [3a: Team Decision Deployment Strategies](/notes/3a/);

--- a/src/content/notes/30.md
+++ b/src/content/notes/30.md
@@ -13,8 +13,6 @@ updateDate: 2023-09-21
 
 ---
 
-- **Previous Note:** [29a: Bet on things that won't change](/notes/29a/);
-- **Next Note:** [30a: Change is inevitable](/notes/30a/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [4b: Monitoring & Inspection to Learn](/notes/4b/);

--- a/src/content/notes/30a.md
+++ b/src/content/notes/30a.md
@@ -14,8 +14,6 @@ What we learn from this experiment is also in another direction. We say that the
 
 ---
 
-- **Previous Note:** [30: Scientific Thinking and Fact-Checking for A Better Life](/notes/30/);
-- **Next Note:** [30b: Why do we suffer in life?](/notes/30b/);
 - **Related Note(s):**
   - [29: Uncertainty is needed to stay open-minded](/notes/29/);
   - [52: Personal Values](/notes/52/);

--- a/src/content/notes/30b.md
+++ b/src/content/notes/30b.md
@@ -11,8 +11,6 @@ Suffering and pain are born from a biological need during evolution. Humans seek
 
 ---
 
-- **Previous Note:** [30a: Change is Inevitable](/notes/30a/);
-- **Next Note:** [30b1: Immunity to suffering requires healthy doses of pain](/notes/30b1/);
 - **Related Note(s):**
   - [46d: Doubts are rarely formed on experience](/notes/46d/);
   - [41b: How to discover creativity?](/notes/41b/);

--- a/src/content/notes/30b1.md
+++ b/src/content/notes/30b1.md
@@ -13,8 +13,6 @@ The important part is learning how to deal with this pain. If we avoid healthy d
 
 ---
 
-- **Previous Note:** [30b: Why do we suffer in life?](/notes/30b/);
-- **Next Note:** [30b2: Emotions are biological](/notes/30b2/);
 - **Related Note(s):**
   - [46e: Choose good problems to deal with](/notes/46e/);
   - [46d: Doubts are rarely formed on experience](/notes/46d/);

--- a/src/content/notes/30b2.md
+++ b/src/content/notes/30b2.md
@@ -15,8 +15,6 @@ It's only logical that our hormones decide what we're annoyed by and what we enj
 
 ---
 
-- **Previous Note:** [30b1: Immunity to suffering requires healthy doses of pain](/notes/30b1/);
-- **Next Note:** [30b3: The Case of Happiness](/notes/30b3/);
 - **Related Note(s):**
   - [41: Characteristics of Creative Work](/notes/41/);
   - [17b: Increasing Public Speaking Skills](/notes/17b/);

--- a/src/content/notes/30b3.md
+++ b/src/content/notes/30b3.md
@@ -16,8 +16,6 @@ The misperception created by the media causes many mental problems. The extraord
 
 ---
 
-- **Previous Note:** [30b2: Emotions are biological](/notes/30b2/);
-- **Next Note:** [30c: Choose good values and good metrics in life](/notes/30c/);
 - **Related Note(s):**
   - [46: Coaching Yourself](/notes/46/);
   - [41b: How to discover creativity?](/notes/41b/);

--- a/src/content/notes/30c.md
+++ b/src/content/notes/30c.md
@@ -13,8 +13,6 @@ The crucial part is that when they want happiness in life, they need to be cauti
 
 ---
 
-- **Previous Note:** [30b3: The Case of Happiness](/notes/30b3/);
-- **Next Note:** [30d: Our lives are full of choices](/notes/30d/);
 - **Related Note(s):**
   - [44: Understanding Differences in Opinions and Perspectives](/notes/44/);
   - [44b: We attribute failure differently](/notes/44b/);

--- a/src/content/notes/30d.md
+++ b/src/content/notes/30d.md
@@ -11,8 +11,6 @@ We always have to choose if we care about something or not. We decide to have a 
 
 ---
 
-- **Previous Note:** [30c: Choose good values and good metrics in life](/notes/30c/);
-- **Next Note:** [30d1: The Rule of Reciprocation](/notes/30d1);
 - **Related Note(s):**
   - [46e: Choose good problems to deal with](/notes/46e/);
   - [44b: We attribute failure differently](/notes/44b/);

--- a/src/content/notes/30d1.md
+++ b/src/content/notes/30d1.md
@@ -14,8 +14,6 @@ We observe that the rule of reciprocation plays a big role everywhere. Almost al
 
 ---
 
-- **Previous Note:** [30d: Our lives are full of choices](/notes/30d/);
-- **Next Note:** [30e: Choose how you want to play with your existing hand](/notes/30e/);
 - **Related Note(s):**
   - [20d: Click and Run](/notes/20d/);
   - [21b: Four stages of the best code review process](/notes/21b/);

--- a/src/content/notes/30e.md
+++ b/src/content/notes/30e.md
@@ -15,6 +15,4 @@ The same applies to life as well. If you are not in a good position from the beg
 
 ---
 
-- **Previous Note:** [30d1: The Rule of Reciprocation](/notes/30d1);
-- **Next Note:** [31: Accountability and Learning Culture in Organizations](/notes/31/);
 - **Source(s):** [The Subtle Art of Not Giving A Fuck by Mark Manson](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);

--- a/src/content/notes/31.md
+++ b/src/content/notes/31.md
@@ -17,8 +17,6 @@ The required transparency and discomfort zone are high, but they are constructiv
 
 ---
 
-- **Previous Note:** [30e: Choose how you want to play with your existing hand](/notes/30e/);
-- **Next Note:** [31a: Create Accountability Cadence](/notes/31a/);
 - **Related Note(s):**
   - [31d: Effectively Learn from mistakes](/notes/31d/);
   - [34: Clarity in Organizations](/notes/34/);

--- a/src/content/notes/31a.md
+++ b/src/content/notes/31a.md
@@ -16,8 +16,6 @@ When people publicly commit, they try harder to make that commitment happen, reg
 
 ---
 
-- **Previous Note:** [31: Accountability and Learning Culture in Organizations](/notes/31/);
-- **Next Note:** [31b: Avoiding Accountability Dysfunction in The Team](/notes/31b/);
 - **Related Note(s):**
   - [15: What should you do when your manager delegates a task to you](/notes/15/);
   - [3c: Giving Ownership to People](/notes/3c/);

--- a/src/content/notes/31b.md
+++ b/src/content/notes/31b.md
@@ -15,8 +15,6 @@ On the peer level, I rarely did this—calling people on. But giving feedback is
 
 ---
 
-- **Previous Note:** [31a: Create Accountability Cadence](/notes/31a/);
-- **Next Note:** [31c: Coaching for Responsibility](/notes/31c/);
 - **Related Note(s):**
   - [23: The First Question of Feedback Discussions](/notes/23/);
   - [33a: Invest in growing your employees](/notes/33a/);

--- a/src/content/notes/31c.md
+++ b/src/content/notes/31c.md
@@ -16,8 +16,6 @@ Encourage people to fail fast. The responsibilities have to be balanced. Nobody 
 
 ---
 
-- **Previous Note:** [31b: Avoiding Accountability Dysfunction in The Team](/notes/31b/);
-- **Next Note:** [31d: Effectively Learn from mistakes](/notes/31d/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [8: Growing in the Career](/notes/8/);

--- a/src/content/notes/31d.md
+++ b/src/content/notes/31d.md
@@ -13,6 +13,4 @@ How effectively do we learn from mistakes? Having different mechanisms, such as 
 
 ---
 
-- **Previous Note:** [31c: Coaching for Responsibility](/notes/31c/);
-- **Next Note:** [32: Communicating Decisions in Organizations](/notes/32/);
 - **Source(s):** [Turn The Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/)

--- a/src/content/notes/32.md
+++ b/src/content/notes/32.md
@@ -12,8 +12,6 @@ Be authentic. Personalization in the language is essential. If we always talk fo
 
 ---
 
-- **Previous Note:** [31d: Effectively Learn from mistakes](/notes/31d/);
-- **Next Note:** [32a: Continually and consistently repeat the message](/notes/32a/);
 - **Related Note(s):**
   - [24b: Specify goals instead of methods or processes](/notes/24b/);
   - [34: Clarity in Organizations](/notes/34/);

--- a/src/content/notes/32a.md
+++ b/src/content/notes/32a.md
@@ -11,7 +11,5 @@ People forget. If we want people to change their minds or apply a new method, th
 
 ---
 
-- **Previous Note:** [32: Communicating Decisions in Organizations](/notes/32/);
-- **Next Note:** [32b: Communicating Organizational Changes](/notes/32b/);
 - **Related Note(s):** [3a: Team Decision Deployment Strategies](/notes/3a/);
 - **Source(s):** [Turn The Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/32b.md
+++ b/src/content/notes/32b.md
@@ -14,8 +14,6 @@ If a leader makes an organizational change, they have to write down clearly what
 
 ---
 
-- **Previous Note:** [32a: Continually and consistently repeat the message](/notes/32a/);
-- **Next Note:** [33: Elevating Others Around You](/notes/33/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [6: Being a boss who cares personally](/notes/6/);

--- a/src/content/notes/33.md
+++ b/src/content/notes/33.md
@@ -20,8 +20,6 @@ Improving competency on technical topics should be supported with mechanisms. Me
 
 ---
 
-- **Previous Note:** [32b: Communicating Organizational Changes](/notes/32b/);
-- **Next Note:** [33a: Invest in growing your employees](/notes/33a/);
 - **Related Note(s):**
   - [24b: Specify goals instead of methods or processes](/notes/24b/);
   - [35: Protective Leadership](/notes/35/);

--- a/src/content/notes/33a.md
+++ b/src/content/notes/33a.md
@@ -13,6 +13,4 @@ If you're not putting your money into the things you ask people to do, no one wi
 
 ---
 
-- **Previous Note:** [33: Elevating Others Around You](/notes/33/);
-- **Next Note:** [34: Clarity in Organizations](/notes/34/);
 - **Source(s):** [Worth Doing Wrong by Arnie S. Malham](/books/worth-doing-wrong-book-summary-review-and-notes/);

--- a/src/content/notes/34.md
+++ b/src/content/notes/34.md
@@ -9,8 +9,6 @@ Clarity is needed in the organization. Everyone needs to fully understand what w
 
 ---
 
-- **Previous Note:** [33a: Invest in growing your employees](/notes/33a/);
-- **Next Note:** [34a: Transparency and respect build trust](/notes/34a/);
 - **Related Note(s):**
   - [24c: People need clarity, not motivation](/notes/24c/);
   - [25b: Making the habit obvious help to break waiting for motivation](/notes/25b/);

--- a/src/content/notes/34a.md
+++ b/src/content/notes/34a.md
@@ -15,8 +15,6 @@ When there is no transparency, people will hear different things—often the wro
 
 ---
 
-- **Previous Note:** [34: Clarity in Organizations](/notes/34/);
-- **Next Note:** [35: Protective Leadership](/notes/35/);
 - **Related Note(s):**
   - [3b1: Building Trust as a New Engineering Manager](/notes/3b1/);
   - [12: Engineer Autonomy](/notes/12/);

--- a/src/content/notes/35.md
+++ b/src/content/notes/35.md
@@ -12,8 +12,6 @@ Taking care of people in the organization doesn't mean keeping them safe from th
 
 ---
 
-- **Previous Note:** [34a: Transparency and respect build trust](/notes/34a/);
-- **Next Note:** [36: Open Feedback Culture](/notes/36/);
 - **Related Note(s):**
   - [Protective Leadership and Finding Your Leadership Style - Software World](https://candost.substack.com/p/14-protective-leadership-and-leadership-style);
   - [44c: Confrontation brings honesty](/notes/44c/);

--- a/src/content/notes/36.md
+++ b/src/content/notes/36.md
@@ -13,8 +13,6 @@ Resilient organizations don't allow mistakes or errors. Even when the captain or
 
 ---
 
-- **Previous Note:** [35: Protective Leadership](/notes/35/);
-- **Next Note:** [37: Setting Organizational Goals and Processes](/notes/37/);
 - **Related Note(s):**
   - [27c: Why Environment Matters More Than You Think When Building Habits](/notes/27c/);
   - [24d: Strong product teams solve customer problems, instead of output](/notes/24d/);

--- a/src/content/notes/37.md
+++ b/src/content/notes/37.md
@@ -16,8 +16,6 @@ Use goals to set a direction and systems to find clues that distract you from th
 
 ---
 
-- **Previous Note:** [36: Open Feedback Culture](/notes/36/);
-- **Next Note:** [37a: Including side work into technical initiatives](/notes/37a/);
 - **Related Note(s):**
   - [17c: Do whatever works for you in your public speaking](/notes/17c/);
   - [27b: How to Learn New Things via Habit Stacking](/notes/27b/);

--- a/src/content/notes/37a.md
+++ b/src/content/notes/37a.md
@@ -10,8 +10,8 @@ updateDate: 2023-09-21
 
 When you sell a technical initiative as a business case successfully, you can use that initiative as an umbrella for others. If other initiatives will contribute to the business case you sold (doesn’t have to be a strong contributor), you can include them as well after you sold it. This looks sneaky at first, but it’s actually your job to make things happen on the engineering side. If you are able to explain how the things you include are related to the case you sold, it’s fine. The stage test is a good model for thinking: if you can answer the question in front of the whole company in public, then it’s alright. For example, if you sold the Continuous Delivery as a business need, you can include some migration efforts and focusing on tech debt in it.
 
-- **Previous Note:** [37: Setting Organizational Goals and Processes](/notes/37/);
-- **Next Note:** [38: Changing Habits Happen in Three Different Ways](/notes/38/);
+---
+
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [24: Strong teams are motivated by goals](/notes/24/);

--- a/src/content/notes/38.md
+++ b/src/content/notes/38.md
@@ -11,8 +11,6 @@ Three levels (outcome, process, identity) of change define our success in changi
 
 ---
 
-- **Previous Note:** [37a: Including side work into technical initiatives](/notes/37a/);
-- **Next Note:** [38a: Focus on who you want to become, not what you want to achieve](/notes/38a/);
 - **Related Note(s):**
   - [25b: Making the habit obvious help to break waiting for motivation](/notes/25b/);
   - [27a: Increasing awareness of the actions and behaviors](/notes/27a/);

--- a/src/content/notes/38a.md
+++ b/src/content/notes/38a.md
@@ -11,8 +11,6 @@ Most of the time, we try to change our habits, starting with outcomes. We focus 
 
 ---
 
-- **Previous Note:** [38: Changing Habits Happen in Three Different Ways](/notes/38/);
-- **Next Note:** [38b: Behaviors run on Auto-pilot](/notes/38b/);
 - **Related Note(s):**
   - [1: Why do we bother to write?](/notes/1/);
   - [8: Growing in the Career](/notes/8/);

--- a/src/content/notes/38b.md
+++ b/src/content/notes/38b.md
@@ -13,8 +13,6 @@ The same situation also happens when we [switch careers](/notes/10/). We need to
 
 ---
 
-- **Previous Note:** [38a: Focus on who you want to become, not what you want to achieve](/notes/38a/);
-- **Next Note:** [39: Increasing Quality of Systems](/notes/39/);
 - **Related Note(s):**
   - [19: Decision-Making Strategies](/notes/19/);
   - [10: Individual Contributor or Manager](/notes/10/);

--- a/src/content/notes/39.md
+++ b/src/content/notes/39.md
@@ -12,8 +12,6 @@ There is a sweet spot in optimizing for quality. The further you try to maximize
 
 ---
 
-- **Previous Note:** [38b: Behaviors run on Auto-pilot](/notes/38b/);
-- **Next Note:** [39a: Best Practices and Consistent Improvement](/notes/39a/);
 - **Related Note(s):**
   - [19d: Why can't this be done sooner?](/notes/19d/);
   - [2: How to Improve Writing](/notes/2/);

--- a/src/content/notes/39a.md
+++ b/src/content/notes/39a.md
@@ -12,8 +12,6 @@ Engineers often struggle to explain their train of thought. They create processe
 
 ---
 
-- **Previous Note:** [39: Increasing Quality of Systems](/notes/39/);
-- **Next Note:** [40: Understanding the Feedback You Receive](/notes/40/);
 - **Related Note(s):**
   - [21: Efficient Code Review Process (The changes I wanted to do in one of my teams)](/notes/21/);
   - [10a: Growing in IC track in Engineering](/notes/10a/);

--- a/src/content/notes/3a.md
+++ b/src/content/notes/3a.md
@@ -20,6 +20,3 @@ In “Big-Bang Deployment,” we terminate one version and deploy the new versio
 The team decision and software deployment strategies are very similar in nature. They both come from hard planning and design. Only the implementation differs. While implementing software, you work hands-on in writing the code. In decision implementation, you talk with people and explain why a decision is made and how it affects them. And the application of the decision is the last step, where we stop talking and start working with the new change.
 
 ---
-
-- **Previous Note:** [3: Being a Team Manager and Manager's Job](/notes/3/);
-- **Next Note:** [3b: Joining A Team As A New Manager](/notes/3b/);

--- a/src/content/notes/3b.md
+++ b/src/content/notes/3b.md
@@ -17,6 +17,4 @@ Be organized. If you promised something, you need to deliver it. Take responsibi
 
 ---
 
-- **Previous Note:** [3a: Team Decision Deployment Strategies](/notes/3a/);
-- **Next Note:** [3b1: Building Trust as a New Engineering Manager](/notes/3b1/);
 - **Source(s):** My Previous Manager

--- a/src/content/notes/3b1.md
+++ b/src/content/notes/3b1.md
@@ -12,6 +12,3 @@ What to do, especially when you don't know the domain and the tech stack?
 Building trust is tricky, but you might have an advantage. If you don't know the tech stack and the domain very well, you should not give suggestions immediately. You should ask questions as an outsider. This can make them realize things they didn't consider before. It will help you to understand the domain without being biased and build trust. When you ask questions, they will see that you care. While asking, admit that you don't know and are trying to learn. This behavior can lower their shield.
 
 ---
-
-- **Previous Note:** [3b: Joining A Team As A New Manager](/notes/3b/);
-- **Next Note:** [3b2: Building Trust as a Leader](/notes/3b2/);

--- a/src/content/notes/3b2.md
+++ b/src/content/notes/3b2.md
@@ -11,6 +11,4 @@ Trust is something like insurance; you have to pay regular contributions to use 
 
 ---
 
-- **Previous Note:** [3b1: Building Trust as a New Engineering Manager](/notes/3b1/);
-- **Next Note:** [3b3: Be Honest and Open to Building Trust](/notes/3b3/);
 - **Related Note(s):** [3: Being a Team Manager and Manager's Job](/notes/3/);

--- a/src/content/notes/3b3.md
+++ b/src/content/notes/3b3.md
@@ -8,6 +8,3 @@ updateDate: 2023-08-16
 Be honest and admit when you don't know. Accept that the team consists of experts who know the work better than you. As long as they see that you are trying to get better at what you do and [you're being empathetic](/the-must-have-skill-for-every-leader-listening-with-empathy/) towards the team you're managing, they will trust you. Be honest and open with the team.
 
 ---
-
-- **Previous Note:** [3b2: Building Trust as a Leader](/notes/3b2/);
-- **Next Note:** [3b4: Make Your Intention Clear](/notes/3b4/);

--- a/src/content/notes/3b4.md
+++ b/src/content/notes/3b4.md
@@ -8,6 +8,3 @@ updateDate: 2023-08-16
 Understand what kind of trust the person wants to build. If the person needs more "personal relationship," ask them how their kids or cats are doing. If they are more inclined to task-based trust, care about their goals, what is important to them and how they define a successful relationship (e.g., if someone says they don't want public praise, don't give them public praise. If they don't wish to public feedback, don't give them feedback in public).
 
 ---
-
-- **Previous Note:** [3b3: Be Honest and Open to Building Trust](/notes/3b3/);
-- **Next Note:** [3b5: Asking Questions to Build Trust with A Direct Report](/notes/3b5/);

--- a/src/content/notes/3b5.md
+++ b/src/content/notes/3b5.md
@@ -18,6 +18,4 @@ Starting as a new manager requires building trust within reports. Trust is trick
 
 ---
 
-- **Previous Note:** [3b4: Make Your Intention Clear](/notes/3b4/);
-- **Next Note:** [3b6: Confident Humility is Required to Build Trust](/notes/3b6/);
 - **Source(s):** The Manager's Path by Camille Fournier

--- a/src/content/notes/3b6.md
+++ b/src/content/notes/3b6.md
@@ -13,6 +13,4 @@ When I think about managers I've worked with, the best ones were the ones who sa
 
 ---
 
-- **Previous Note:** [3b5: Asking Questions to Build Trust with A Direct Report](/notes/3b5/);
-- **Next Note:** [3c: Giving Ownership to People](/notes/3c/);
 - **Source(s):** [Think Again by Adam Grant](/books/think-again-by-adam-grant-book-summary-review-and-notes/);

--- a/src/content/notes/3c.md
+++ b/src/content/notes/3c.md
@@ -13,6 +13,4 @@ If you want to give ownership, don't just preach and hope for the best. Implemen
 
 ---
 
-- **Previous Note:** [3b6: Confident Humility is Required to Build Trust](/notes/3b6/);
-- **Next Note:** [3c1: Autonomy and Ownership Requires Technical Capability](/notes/3c1/);
 - **Source(s):** [Turn the Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/3c1.md
+++ b/src/content/notes/3c1.md
@@ -15,6 +15,4 @@ Seeing training as increasing decision-making authority is a good way. It makes 
 
 ---
 
-- **Previous Note:** [3c: Giving Ownership to People](/notes/3c/);
-- **Next Note:** [3c2: Creating an Agenda for 1:1s with Your Manager](/notes/3c2/);
 - **Source(s):** [Think Again by Adam Grant](/books/think-again-by-adam-grant-book-summary-review-and-notes/);

--- a/src/content/notes/3c2.md
+++ b/src/content/notes/3c2.md
@@ -30,6 +30,4 @@ So here are the exact titles in our document:
 
 ---
 
-- **Previous Note:** [3c1: Autonomy and Ownership Requires Technical Capability](/notes/3c1/);
-- **Next Note:** [3c3: Giving ownership to people by delegation](/notes/3c3/);
 - **Resourced:** [Effective 1:1 Meetings—1-on-1 Meeting Template](/effective-1-1-meetings-one-on-one-meeting-template/);

--- a/src/content/notes/3c3.md
+++ b/src/content/notes/3c3.md
@@ -16,6 +16,4 @@ If you want projects moving and initiatives running, assign a responsible person
 
 ---
 
-- **Previous Note:** [3c2: Creating an Agenda for 1:1s with Your Manager](/notes/3c2/);
-- **Next Note:** [3c3a: Using Delegation Checklist](/notes/3c3a/);
 - **Source(s):** [Worth Doing Wrong by Arnie S. Malham](/books/worth-doing-wrong-book-summary-review-and-notes/);

--- a/src/content/notes/3c3a.md
+++ b/src/content/notes/3c3a.md
@@ -27,8 +27,6 @@ When I try to delegate a job to people, I mostly consider their skills, where th
 
 ---
 
-- **Previous Note:** [3c3: Giving ownership to people by delegation](/notes/3c3/);
-- **Next Note:** [3c4: Working with and leading blame absorbers](/notes/3c4/);
 - **Related Note(s):**
   - [12: Engineer Autonomy](/notes/12/);
   - [15: What should you do when your manager delegates a task to you](/notes/15/);

--- a/src/content/notes/3c4.md
+++ b/src/content/notes/3c4.md
@@ -13,8 +13,6 @@ If you let this slip, it builds resentment over time. The absorber starts to thi
 
 ---
 
-- **Previous Note:** [3c3a: Using Delegation Checklist](/notes/3c3a/);
-- **Next Note:** [3d: Teams need emancipation, not empowerment](/notes/3d/);
 - **Source(s):** Thanks for The Feedback by Douglas Stone & Sheila Heen
 - **Resourced:**
   - [A Systematic Approach to Give Feedback to Blame Absorbers](/systematic-approach-to-give-feedback-to-blame-absorbers/);

--- a/src/content/notes/3d.md
+++ b/src/content/notes/3d.md
@@ -11,6 +11,4 @@ Empowerment doesn't work without clarity and competence—empowerment results fr
 
 ---
 
-- **Previous Note:** [3c4: Working with and leading blame absorbers](/notes/3c4/);
-- **Next Note:** [3e: Setting Clear Expectations About Communication and Collaboration](/notes/3e/);
 - **Source(s):** [Turn the Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/3e.md
+++ b/src/content/notes/3e.md
@@ -12,6 +12,4 @@ Sharing status updates doesn't mean the team is collaborating. We need to organi
 
 ---
 
-- **Previous Note:** [3d: Teams need emancipation, not empowerment](/notes/3d/);
-- **Next Note:** [4: Monitoring Work of Direct Reports](/notes/4/);
 - **Source(s):** [Bottleneck #03: Product v Engineering](https://martinfowler.com/articles/bottlenecks-of-scaleups/03-product-v-engineering.html);

--- a/src/content/notes/4.md
+++ b/src/content/notes/4.md
@@ -11,6 +11,4 @@ Top-down monitoring systems like tracking everything people do at work are not e
 
 ---
 
-- **Previous Note:** [3e: Setting Clear Expectations About Communication and Collaboration](/notes/3e/);
-- **Next Note:** [4a: On Being Curious](/notes/4a/);
 - **Source(s):** [Turn the Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/40.md
+++ b/src/content/notes/40.md
@@ -13,8 +13,6 @@ The feedback in relationships is never about you or me. It's about you AND me. I
 
 ---
 
-- **Previous Note:** [39a: Best Practices and Consistent Improvement](/notes/39a/);
-- **Next Note:** [40a: Switchtrack conversations](/notes/40a/);
 - **Related Note(s):**
   - [5: Managing Promotions](/notes/5/);
   - [3: Being a Team Manager and Manager's Job](/notes/3/);

--- a/src/content/notes/40a.md
+++ b/src/content/notes/40a.md
@@ -13,8 +13,6 @@ In the feedback discussion, there are relationship triggers. The feedback comes 
 
 ---
 
-- **Previous Note:** [40: Understanding the Feedback You Receive](/notes/40/);
-- **Next Note:** [40b: Creating accidental adversaries](/notes/40b/);
 - **Related Note(s):**
   - [44: Understanding Differences in Opinions and Perspectives](/notes/44/);
   - [40c: Learning How to Receive Feedback](/notes/40c/);

--- a/src/content/notes/40b.md
+++ b/src/content/notes/40b.md
@@ -13,8 +13,6 @@ We create accidental adversaries because of a lack of clarity or confusion in ro
 
 ---
 
-- **Previous Note:** [40a: Switchtrack conversations](/notes/40a/);
-- **Next Note:** [40c: Learning How to Receive Feedback](/notes/40c/);
 - **Related Note(s):**
   - [34: Clarity in Organizations](/notes/34/);
   - [36: Open Feedback Culture](/notes/36/);

--- a/src/content/notes/40c.md
+++ b/src/content/notes/40c.md
@@ -13,8 +13,6 @@ Master the pulling feedback skills that drive our learning and curiosity. We alw
 
 ---
 
-- **Previous Note:** [40b: Creating accidental adversaries](/notes/40b/);
-- **Next Note:** [40d: How do I behave when I receive feedback?](/notes/40d/);
 - **Related Note(s):**
   - [30d: Our lives are full of choices](/notes/30d/);
   - [44c: Confrontation brings honesty](/notes/44c/);

--- a/src/content/notes/40d.md
+++ b/src/content/notes/40d.md
@@ -11,8 +11,6 @@ Reactions to feedback define how the feedback giver perceives the other person's
 
 ---
 
-- **Previous Note:** [40c: Learning How to Receive Feedback](/notes/40c/);
-- **Next Note:** [40d1: Trying the feedback](/notes/40d1/);
 - **Related Note(s):**
   - [20: Influencing Others](/notes/20/);
   - [23: The First Question of Feedback Discussions](/notes/23/);

--- a/src/content/notes/40d1.md
+++ b/src/content/notes/40d1.md
@@ -11,8 +11,6 @@ When we receive feedback, we might consider applying it fully or declining it. I
 
 ---
 
-- **Previous Note:** [40d: How do I behave when I receive feedback?](/notes/40d/);
-- **Next Note:** [40e: Tell the other side what's been left out](/notes/40e/);
 - **Related Note(s):**
   - [2: How to Improve Writing](/notes/2/);
   - [3: Being a Team Manager and Manager's Job](/notes/3/);

--- a/src/content/notes/40e.md
+++ b/src/content/notes/40e.md
@@ -11,8 +11,6 @@ While receiving [a code review](/notes/21/), we need to express ourselves and co
 
 ---
 
-- **Previous Note:** [40d1: Trying the feedback](/notes/40d1/);
-- **Next Note:** [41: Characteristics of Creative Work](/notes/41/);
 - **Related Note(s):**
   - [21: Efficient Code Review Process (The changes I wanted to do in one of my teams)](/notes/21/);
   - [Maximizing Personal Growth by Understanding Feedback You Get](/maximizing-personal-growth-by-understanding/);

--- a/src/content/notes/41.md
+++ b/src/content/notes/41.md
@@ -9,8 +9,6 @@ Every idea in each creative process has inconsistencies and missing parts. They 
 
 ---
 
-- **Previous Note:** [40e: Tell the other side what's been left out](/notes/40e/);
-- **Next Note:** [41a: Difference between an amateur and a professional](/notes/41a/);
 - **Related Note(s):**
   - [41b: How to discover creativity?](/notes/41b/);
   - [52b: Accepting Death Destroys Entitlement](/notes/52b/);

--- a/src/content/notes/41a.md
+++ b/src/content/notes/41a.md
@@ -11,8 +11,6 @@ At the same time, in our professional endeavors, we never drop. Even when we're 
 
 ---
 
-- **Previous Note:** [41: Characteristics of Creative Work](/notes/41/);
-- **Next Note:** [41b: How to discover creativity?](/notes/41b/);
 - **Related Note(s):**
   - [1: Why do we bother to write?](/notes/1/);
   - [2a: Take breaks to write better](/notes/2a/);

--- a/src/content/notes/41b.md
+++ b/src/content/notes/41b.md
@@ -19,8 +19,6 @@ Set aside some time and go over the following to find out your creative sides:
 
 ---
 
-- **Previous Note:** [41a: Difference between an amateur and a professional](/notes/41a/);
-- **Next Note:** [41b1: Our minds are changeable; we can get rid of our inner critic](/notes/41b1/);
 - **Related Note(s):**
   - [52a: Accepting one thing requires saying no to other things](/notes/52a/);
   - [Software World #17: Banish Your Inner Critic with Denise Jacobs](https://candost.substack.com/p/17-banish-your-inner-critic-with-638/);

--- a/src/content/notes/41b1.md
+++ b/src/content/notes/41b1.md
@@ -9,6 +9,4 @@ We believe that our minds and, therefore, behaviors are not changeable. On the c
 
 ---
 
-- **Previous Note:** [41b: How to discover creativity?](/notes/41b/);
-- **Next Note:** [41c: Do something principle](/notes/41c/);
 - **Source(s):** [Banish Your Inner Critic by Denise Jacobs](https://innercriticbook.com/);

--- a/src/content/notes/41c.md
+++ b/src/content/notes/41c.md
@@ -13,6 +13,4 @@ If you take action and do something before waiting for anything (no inspiration,
 
 ---
 
-- **Previous Note:** [41b1: Our minds are changeable; we can get rid of our inner critic](/notes/41b1/);
-- **Next Note:** [41d: Sometimes, it just needs to be felt right](/notes/41d/);
 - **Source(s):** [The Subtle Art of Not Giving A Fuck by Mark Manson](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);

--- a/src/content/notes/41d.md
+++ b/src/content/notes/41d.md
@@ -16,8 +16,6 @@ When Auri found a new room and inside a drawer full of clean and high-quality sh
 
 ---
 
-- **Previous Note:** [41c: Do something principle](/notes/41c/);
-- **Next Note:** [42: What to Consider While Designing a Software System](/notes/42/);
 - **Related Note(s):**
   - [1: Why do we bother to write?](/notes/1/);
   - [27: Developing Habits](/notes/27/);

--- a/src/content/notes/42.md
+++ b/src/content/notes/42.md
@@ -14,8 +14,6 @@ Conceptual integrity is the most important thing in system design. Therefore, pe
 
 ---
 
-- **Previous Note:** [41d: Sometimes, it just needs to be felt right](/notes/41d/);
-- **Next Note:** [42a: Top Level Partitioning](/notes/42a/);
 - **Related Note(s):**
   - [21: Efficient Code Review Process (The changes I wanted to do in one of my teams)](/notes/21/);
   - [33: Elevating Others Around You](/notes/33/);

--- a/src/content/notes/42a.md
+++ b/src/content/notes/42a.md
@@ -12,8 +12,6 @@ The software architect decides the boundaries of components. The components are 
 
 ---
 
-- **Previous Note:** [42: What to Consider While Designing a Software System](/notes/42/);
-- **Next Note:** [42b: Systems and Design Thinking](/notes/42b/);
 - **Related Note(s):**
   - [19a: Knowns and Unknowns](/notes/19a/);
   - [26: The Cost of Software Deployment and Continuous Delivery](/notes/26/);

--- a/src/content/notes/42b.md
+++ b/src/content/notes/42b.md
@@ -11,8 +11,6 @@ We can define traditional systems thinking as separating the system into parts, 
 
 ---
 
-- **Previous Note:** [42a: Top Level Partitioning](/notes/42a/);
-- **Next Note:** [42c: Actors/actions model](/notes/42c/);
 - **Related Note(s):**
   - [43: The Role and Responsibility of Software Architect](/notes/43/);
   - [51: Consistency Models in Distributed Systems Index](/notes/51/);

--- a/src/content/notes/42c.md
+++ b/src/content/notes/42c.md
@@ -11,8 +11,6 @@ Thinking and finding out how the actors will handle the incoming communication a
 
 ---
 
-- **Previous Note:** [42b: Systems and Design Thinking](/notes/42b/);
-- **Next Note:** [42d: Component discovery with Event Storming](/notes/42d/);
 - **Related Note(s):**
   - [43: The Role and Responsibility of Software Architect](/notes/43/);
   - [19a: Knowns and Unknowns](/notes/19a/);

--- a/src/content/notes/42d.md
+++ b/src/content/notes/42d.md
@@ -12,8 +12,6 @@ Event Storming is a component discovery technique from Domain-Driven Design. An 
 
 ---
 
-- **Previous Note:** [42c: Actors/actions model](/notes/42c/);
-- **Next Note:** [42e: Use Second-Order Thinking](/notes/42e/);
 - **Related Note(s):**
   - [43: The Role and Responsibility of Software Architect](/notes/43/);
   - [42: What to Consider While Designing a Software System](/notes/42/);

--- a/src/content/notes/42e.md
+++ b/src/content/notes/42e.md
@@ -12,8 +12,6 @@ While rebuilding a service or migrating from one technology to another, people o
 
 ---
 
-- **Previous Note:** [42d: Component discovery with Event Storming](/notes/42d/);
-- **Next Note:** [43: The Role and Responsibility of Software Architect](/notes/43/);
 - **Related Note(s):**
   - [19a: Knowns and Unknowns](/notes/19a/);
   - [3: Being a Team Manager and Manager's Job](/notes/3/);

--- a/src/content/notes/43.md
+++ b/src/content/notes/43.md
@@ -9,8 +9,6 @@ The level of the architect's involvement in the project should be certain and no
 
 ---
 
-- **Previous Note:** [42e: Use Second-Order Thinking](/notes/42e/);
-- **Next Note:** [44: Understanding Differences in Opinions and Perspectives](/notes/44/);
 - **Related Note(s):**
   - [42: What to Consider While Designing a Software System](/notes/42/);
   - [19c: How to move faster in organizations](/notes/19c/);

--- a/src/content/notes/44.md
+++ b/src/content/notes/44.md
@@ -13,8 +13,6 @@ Everyone has their own rules in their heads. We interpret and evaluate situation
 
 ---
 
-- **Previous Note:** [43: The Role and Responsibility of Software Architect](/notes/43/);
-- **Next Note:** [44a: Explicit disagreement is better than implicit misunderstanding](/notes/44a/);
 - **Related Note(s):**
   - [40c: Learning How to Receive Feedback](/notes/40c/);
   - [27a: Increasing awareness of the actions and behaviors](/notes/27a/);

--- a/src/content/notes/44a.md
+++ b/src/content/notes/44a.md
@@ -12,8 +12,6 @@ When giving or receiving feedback, the statement is true. But I couldn't stop my
 
 ---
 
-- **Previous Note:** [44: Understanding Differences in Opinions and Perspectives](/notes/44/);
-- **Next Note:** [44b: We attribute failure differently](/notes/44b/);
 - **Related Note(s):**
   - [44: Understanding Differences in Opinions and Perspectives](/notes/44/);
   - [27a: Increasing awareness of the actions and behaviors](/notes/27a/);

--- a/src/content/notes/44b.md
+++ b/src/content/notes/44b.md
@@ -13,8 +13,6 @@ The difference in perspectives is the point that requires more empathy. While pr
 
 ---
 
-- **Previous Note:** [44a: Explicit disagreement is better than implicit misunderstanding](/notes/44a/);
-- **Next Note:** [44c: Confrontation brings honesty](/notes/44c/);
 - **Related Note(s):**
   - [41b: How to discover creativity?](/notes/41b/);
   - [40c: Learning How to Receive Feedback](/notes/40c/);

--- a/src/content/notes/44c.md
+++ b/src/content/notes/44c.md
@@ -14,8 +14,6 @@ Only you can be honest with yourself if you are honest with others. That's where
 
 ---
 
-- **Previous Note:** [44b: We attribute failure differently](/notes/44b/);
-- **Next Note:** [44d: Without conflict, there can be no trust](/notes/44d/);
 - **Related Note(s):**
   - [13: Be Kind at Work](/notes/13/);
   - [7: Confident Humility](/notes/7/);

--- a/src/content/notes/44d.md
+++ b/src/content/notes/44d.md
@@ -14,8 +14,6 @@ Society forces us to be the same, although individuals differ. Always confirming
 
 ---
 
-- **Previous Note:** [44c: Confrontation brings honesty](/notes/44c/);
-- **Next Note:** [44e: Relationship vs. Task Conflict](/notes/44e/);
 - **Related Note(s):**
   - [19: Decision-Making Strategies](/notes/19/);
   - [20: Influencing Others](/notes/20/);

--- a/src/content/notes/44e.md
+++ b/src/content/notes/44e.md
@@ -21,8 +21,6 @@ Additionally, **Conflicts are necessary for improvement and growth and are a hea
 
 ---
 
-- **Previous Note:** [44d: Without conflict, there can be no trust](/notes/44d/);
-- **Next Note:** [44f: Unclear WHYs create more relationship conflicts](/notes/44f/);
 - **Related Note(s):**
   - [21: Efficient Code Review Process (The changes I wanted to do in one of my teams)](/notes/21/);
   - [22: Cross-Cultural Communication](/notes/22/);

--- a/src/content/notes/44f.md
+++ b/src/content/notes/44f.md
@@ -11,8 +11,6 @@ When Simon Sinek recommended [starting with why](https://simonsinek.com/books/st
 
 ---
 
-- **Previous Note:** [44e: Relationship vs. Task Conflict](/notes/44e/);
-- **Next Note:** [44g: Persuading others requires accepting their arguments and building empathy](/notes/44g/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [32: Communicating Decisions in Organizations](/notes/32/);

--- a/src/content/notes/44g.md
+++ b/src/content/notes/44g.md
@@ -11,8 +11,6 @@ We should change our perspective, see the other side's strongest argument, and a
 
 ---
 
-- **Previous Note:** [44f: Unclear WHYs create more relationship conflicts](/notes/44f/);
-- **Next Note:** [44h: Present humility and ask questions to persuade others](/notes/44h/);
 - **Related Note(s):**
   - [19b: Consent-Based Decision Making](/notes/19b/);
   - [17i: How to Understand The Public Talk Feedback You Get](/notes/17i/);

--- a/src/content/notes/44h.md
+++ b/src/content/notes/44h.md
@@ -9,8 +9,6 @@ Irrationally repeating the same arguments, staying the same line repeatedly, and
 
 ---
 
-- **Previous Note:** [44g: Persuading others requires accepting their arguments and building empathy](/notes/44g/);
-- **Next Note:** [44i: Ask questions that nudge the other side to explore the roots of their stereotypes](/notes/44i/);
 - **Related Note(s):**
   - [4a: On Being Curious](/notes/4a/);
   - [8d: Ask Questions](/notes/8d/);

--- a/src/content/notes/44i.md
+++ b/src/content/notes/44i.md
@@ -11,6 +11,4 @@ The fish is never aware of its surroundings. Everywhere is water for it; thus, i
 
 ---
 
-- **Previous Note:** [44i: Ask questions that nudge the other side to explore the roots of their stereotypes](/notes/44i/);
-- **Next Note:** [44j: Instead of giving advice directly, use an empathetic approach](/notes/44j/);
 - **Source(s):** [Think Again by Adam Grant](/books/think-again-by-adam-grant-book-summary-review-and-notes/);

--- a/src/content/notes/44j.md
+++ b/src/content/notes/44j.md
@@ -12,8 +12,6 @@ updateDate: 2023-09-21
 
 ---
 
-- **Previous Note:**[44i: Ask questions that nudge the other side to explore the roots of their stereotypes](/notes/44i/);
-- **Next Note:** [44k: Overcoming Binary Bias and Polarization](/notes/44k/);
 - **Related Note(s):**
   - [33: Elevating Others Around You](/notes/33/);
   - [6: Being a boss who cares personally](/notes/6/);

--- a/src/content/notes/44k.md
+++ b/src/content/notes/44k.md
@@ -16,8 +16,6 @@ To unstuck ourselves from binary bias, we must be exposed to different perspecti
 
 ---
 
-- **Previous Note:** [44j: Instead of giving advice directly, use an empathetic approach](/notes/44j/);
-- **Next Note:** [44l: Be part of the conversation and also the manager while receiving feedback](/notes/44l/)l
 - **Related Note(s):**
   - [4a: On Being Curious](/notes/4a/);
   - [33: Elevating Others Around You](/notes/33/);

--- a/src/content/notes/44l.md
+++ b/src/content/notes/44l.md
@@ -12,8 +12,6 @@ Great communicators are both the managers and a part of the feedback conversatio
 
 ---
 
-- **Previous Note:** [44k: Overcoming Binary Bias and Polarization](/notes/44k/);
-- **Next Note:** [45: Software Architecture Patterns and Models](/notes/45/);
 - **Related Note(s):**
   - [8: Growing in the Career](/notes/8/);
   - [7: Confident Humility](/notes/7/);

--- a/src/content/notes/45.md
+++ b/src/content/notes/45.md
@@ -14,6 +14,4 @@ Creating entity managers to perform CRUD operations is not architectural thinkin
 
 ---
 
-- **Previous Note:** [44l: Be part of the conversation and also the manager while receiving feedback](/notes/44l/);
-- **Next Note:** [45a: Architecture Sinkhole Anti-Pattern](/notes/45a/);
 - **Source(s):** [Fundamentals of Software Architecture by Mark Richards & Neal Ford](http://fundamentalsofsoftwarearchitecture.com/)

--- a/src/content/notes/45a.md
+++ b/src/content/notes/45a.md
@@ -13,8 +13,6 @@ Although it looks like it is happening more in layered architectures, I also saw
 
 ---
 
-- **Previous Note:** [45: Software Architecture Patterns and Models](/notes/45/);
-- **Next Note:** [46: Coaching Yourself](/notes/46/);
 - **Related Note(s):**
   - [48: System Design Index](/notes/48/);
   - [49: Accidental Complexity](/notes/49/);

--- a/src/content/notes/46.md
+++ b/src/content/notes/46.md
@@ -13,8 +13,6 @@ The only face we don't see and cannot read is ours. We always think about our th
 
 ---
 
-- **Previous Note:** [45a: Architecture Sinkhole Anti-Pattern](/notes/45a/);
-- **Next Note:** [46a: Intentions, Behaviors, and Their Impact](/notes/46a/);
 - **Related Note(s):**
   - [41: Characteristics of Creative Work](/notes/41/);
   - [2a: Take breaks to write better](/notes/2a/);

--- a/src/content/notes/46a.md
+++ b/src/content/notes/46a.md
@@ -14,8 +14,6 @@ Our behaviors affect others, not our intention. How do we align our intention, b
 
 ---
 
-- **Previous Note:** [46: Coaching Yourself](/notes/46/);
-- **Next Note:** [46b: Impact of Imposter Syndrome](/notes/46b/);
 - **Related Note(s):**
   - [44: Understanding Differences in Opinions and Perspectives](/notes/44/);
   - [40c: Learning How to Receive Feedback](/notes/40c/);

--- a/src/content/notes/46b.md
+++ b/src/content/notes/46b.md
@@ -18,8 +18,6 @@ It makes us better learners. When we doubt our knowledge, we're more open to lea
 
 ---
 
-- **Previous Note:** [46a: Intentions, Behaviors, and Their Impact](/notes/46a/);
-- **Next Note:** [46c: Have regular career and relationships check-ups](/notes/46c/);
 - **Related Note(s):**
   - [4a: On Being Curious](/notes/4a/);
   - [27a: Increasing awareness of the actions and behaviors](/notes/27a/);

--- a/src/content/notes/46c.md
+++ b/src/content/notes/46c.md
@@ -11,8 +11,6 @@ We should have some checkpoints in our careers to evaluate how it's going.
 
 ---
 
-- **Previous Note:** [46b: Impact of Imposter Syndrome](/notes/46b/);
-- **Next Note:** [46d: Doubts are rarely formed on experience](/notes/46d/);
 - **Related Note(s):**
   - [8: Growing in the Career](/notes/8/);
   - [37: Setting Organizational Goals and Processes](/notes/37/);

--- a/src/content/notes/46d.md
+++ b/src/content/notes/46d.md
@@ -18,8 +18,6 @@ Journaling helps to figure out what worked and what didn't. The experience log i
 
 ---
 
-- **Previous Note:** [46c: Have regular career and relationships check-ups](/notes/46c/);
-- **Next Note:** [46d1: Measuring self-worth comes from negative experiences](/notes/46d1/);
 - **Related Note(s):**
   - [41b: How to discover creativity?](/notes/41b/);
   - [2b: How to get rid of distractions in your head while you write](/notes/2b/);

--- a/src/content/notes/46d1.md
+++ b/src/content/notes/46d1.md
@@ -9,7 +9,5 @@ When we evaluate ourselves, we put some measurements. Depending on the measure, 
 
 ---
 
-- **Previous Note:** [46d: Doubts are rarely formed on experience](/notes/46d/);
-- **Next Note:** [46e: Choose good problems to deal with](/notes/46e/);
 - **Related Note(s):** [30c: Choose good values and good metrics in life](/notes/30c/);
 - **Source(s):** [The Subtle Art of Not Giving A Fuck by Mark Manson](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);

--- a/src/content/notes/46e.md
+++ b/src/content/notes/46e.md
@@ -14,8 +14,6 @@ Good goals are more important ones and change from person to person. Upon choosi
 
 ---
 
-- **Previous Note:** [46d1: Measuring self-worth comes from negative experiences](/notes/46d1/);
-- **Next Note:** [46f: Reflexive Psychology to Learn More About Yourself](/notes/46f/);
 - **Related Note(s):**
   - [27f1: Build your skills gradually to climb Mount Everest](/notes/27f1/);
   - [4a: On Being Curious](/notes/4a/);

--- a/src/content/notes/46f.md
+++ b/src/content/notes/46f.md
@@ -12,8 +12,6 @@ In a dinner with a colleague, we talked about psychology in leadership. They wer
 
 ---
 
-- **Previous Note:** [46e: Choose good problems to deal with](/notes/46e/);
-- **Next Note:** [47: Software Architecture Styles Index](/notes/47/);
 - **Related Note(s):**
   - [1: Why do we bother to write?](/notes/1/);
   - [4: Monitoring Work of Direct Reports](/notes/4/);

--- a/src/content/notes/47.md
+++ b/src/content/notes/47.md
@@ -14,6 +14,4 @@ updateDate: 2023-09-21
 
 ---
 
-- **Previuos Note:** [46f: Reflexive Psychology to Learn More About Yourself](/notes/46f/);
-- **Next Note:** [47a: Layered Software Architecture](/notes/47a/);
 - **Related Note(s):** [42b: Systems and Design Thinking](/notes/42b/);

--- a/src/content/notes/47a.md
+++ b/src/content/notes/47a.md
@@ -13,8 +13,6 @@ In open layers, the request can bypass layers (until it hits a closed layer) and
 
 ---
 
-- **Previous Note:** [47: Software Architecture Styles Index](/notes/47/);
-- **Next Note:** [47a1: Layers of Isolation](/notes/47a1/);
 - **Related Note(s):**
   - [42b: Systems and Design Thinking](/notes/42b/);
   - [48: System Design Index](/notes/48/);

--- a/src/content/notes/47a1.md
+++ b/src/content/notes/47a1.md
@@ -14,6 +14,4 @@ Wrappers partially do this job but on the lower levels. Isolating a presentation
 
 ---
 
-- **Previous Note:** [47a: Layered Software Architecture](/notes/47a/);
-- **Next Note:** [47b: Pipeline Architecture Style](/notes/47b/);
 - **Source(s):** [Fundamentals of Software Architecture by Mark Richards & Neal Ford](http://fundamentalsofsoftwarearchitecture.com/);

--- a/src/content/notes/47b.md
+++ b/src/content/notes/47b.md
@@ -19,6 +19,4 @@ The worst part is it's not fault-tolerant. One of the failures in any part cause
 
 ---
 
-- **Previous Note:** [47a1: Layers of Isolation](/notes/47a1/);
-- **Next Note:** [48: System Design Index](/notes/48/);
 - **Source(s):** [Fundamentals of Software Architecture by Mark Richards & Neal Ford](http://fundamentalsofsoftwarearchitecture.com/);

--- a/src/content/notes/48.md
+++ b/src/content/notes/48.md
@@ -16,6 +16,4 @@ updateDate: 2023-09-21
 
 ---
 
-- **Previous Note:** [47b: Pipeline Architecture Style](/notes/47b/);
-- **Next Note:** [48a: Fault Tolerance & Resiliency](/notes/48a/);
 - **Related Note(s):** [51a: Database Race Conditions](/notes/51a/);

--- a/src/content/notes/48a.md
+++ b/src/content/notes/48a.md
@@ -9,6 +9,4 @@ The systems that can tolerate the faults are called fault-tolerant or resilient.
 
 ---
 
-- **Previous Note:** [48: System Design Index](/notes/48/);
-- **Next Note:** [48b: Putting servers close to clients](/notes/48b/);
 - **Source(s):** Designing Data-Intensive Applications by Martin Kleppmann

--- a/src/content/notes/48b.md
+++ b/src/content/notes/48b.md
@@ -13,6 +13,4 @@ Lowering the handshake fastens the connection. The earlier the handshake ends, t
 
 ---
 
-- **Previous Note:** [48a: Fault Tolerance & Resiliency](/notes/48a/);
-- **Next Note:** [48c: The CAP Theorem](/notes/48c/);
 - **Source(s):** Designing Data-Intensive Applications by Martin Kleppmann

--- a/src/content/notes/48c.md
+++ b/src/content/notes/48c.md
@@ -11,8 +11,6 @@ updateDate: 2023-09-21
 
 ---
 
-- **Previous Note:** [48b: Putting servers close to clients](/notes/48b/);
-- **Next Note:** [48d: Elasticity in Software Systems](/notes/48d/);
 - **Related Note(s):**
   - [43: The Role and Responsibility of Software Architect](/notes/43/);
   - [45: Software Architecture Patterns and Models](/notes/45/);

--- a/src/content/notes/48d.md
+++ b/src/content/notes/48d.md
@@ -17,6 +17,4 @@ Serverless architecture is one of the most elastic systems. You pay-per-use, and
 
 ---
 
-- **Previous Note:** [48c: The CAP Theorem](/notes/48c/);
-- **Next Note:** [49: Accidental Complexity](/notes/49/);
 - **Source(s):** [Fundamentals of Software Architecture by Mark Richards & Neal Ford](http://fundamentalsofsoftwarearchitecture.com/);

--- a/src/content/notes/49.md
+++ b/src/content/notes/49.md
@@ -9,6 +9,4 @@ Accidental complexity happens when teams don't care about their codebase, applic
 
 ---
 
-- **Previous Note:** [48d: Elasticity in Software Systems](/notes/48d/);
-- **Next Note:** [49a: The More accidental complexity the less quality](/notes/49a/);
 - **Source(s):** Designing Data-Intensive Applications by Martin Kleppmann

--- a/src/content/notes/49a.md
+++ b/src/content/notes/49a.md
@@ -8,6 +8,3 @@ updateDate: 2023-09-21
 When accidental complexity builds up, the [quality of the systems](/notes/39/) reduces. I've also seen that engineers have a hard time [clearly stating the problems](/notes/34/).
 
 ---
-
-- **Previous Note:** [49: Accidental Complexity](/notes/49/);
-- **Next Note:** [50: Service Level Agreements/Indicators/Objectives - Percentiles](/notes/50/);

--- a/src/content/notes/4a.md
+++ b/src/content/notes/4a.md
@@ -11,7 +11,5 @@ Asking questions has two sides: questioning and curiosity. Which one are you doi
 
 ---
 
-- **Previous Note:** [4: Monitoring Work of Direct Reports](/notes/4/);
-- **Next Note:** [4b: Monitoring & Inspection to Learn](/notes/4b/);
 - **Source(s):** [Turn the Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);
 - **Resourced:** [Questioning vs. Asking](/questioning-vs-asking/);

--- a/src/content/notes/4b.md
+++ b/src/content/notes/4b.md
@@ -11,6 +11,4 @@ Embracing inspections/monitoring and third parties to check how you are doing is
 
 ---
 
-- **Previous Note:** [4a: On Being Curious](/notes/4a/);
-- **Next Note:** [4c: Howthorne Effect](/notes/4c/);
 - **Source(s):** [Turn the Ship Around](/books/turn-the-ship-around-summary-book-chapter-notes/);

--- a/src/content/notes/4c.md
+++ b/src/content/notes/4c.md
@@ -15,8 +15,6 @@ At the Western Electric plant, a study was conducted in the 1920s to explore met
 
 ---
 
-- **Previous Note:** [4b: Monitoring & Inspection to Learn](/notes/4b/);
-- **Next Note:** [4d: Leveraging Hawthorne Effect at Work](/notes/5/);
 - **Related Note(s):**
   - [37: Setting Organizational Goals and Processes](/notes/37/);
   - [41: Characteristics of Creative Work](/notes/41/);

--- a/src/content/notes/4d.md
+++ b/src/content/notes/4d.md
@@ -15,8 +15,6 @@ The important part is figuring out how to turn this into a positive effect. This
 
 ---
 
-- **Previous Note:** [4c: Howthorne Effect](/notes/4c/);
-- **Next Note:** [4e: Compliment to improve occasional good behavior](/notes/4e/);
 - **Related Note(s):**
   - [3e: Setting Clear Expectations About Communication and Collaboration](/notes/3e/);
   - [20: Influencing Others](/notes/20/);

--- a/src/content/notes/4e.md
+++ b/src/content/notes/4e.md
@@ -11,8 +11,6 @@ When someone gets compliment on something they are doing good, they try to perfe
 
 ---
 
-- **Previous Note:** [4d: Leveraging Hawthorne Effect at Work](/notes/5/);
-- **Next Note:** [5: Managing Promotions](/notes/5/);
 - **Related Note(s):**
   - [4: Monitoring Work of Direct Reports](/notes/4/);
   - [20d: Click and Run](/notes/20d/);

--- a/src/content/notes/5.md
+++ b/src/content/notes/5.md
@@ -15,6 +15,4 @@ For more senior roles, it's tricky. Find the stretch projects where they need to
 
 ---
 
-- **Previous Note**: [4e: Compliment to improve occasional good behavior](/notes/4e/);
-- **Next Note:** [5a: Why people who are growing too fast can have low performance](/notes/5a/);
 - **Source(s):** The Manager's Path by Camille Fournier

--- a/src/content/notes/50.md
+++ b/src/content/notes/50.md
@@ -13,8 +13,6 @@ We also talk about the mean in response times. The mean response time is actuall
 
 ---
 
-- **Previous Note:** [49a: The More accidental complexity the less quality](/notes/49a/);
-- **Next Note:** [51: Consistency Models in Distributed Systems Index](/notes/51/);
 - **Related Note(s):**
   - [49: Accidental Complexity](/notes/49/);
   - [48: System Design Index](/notes/48/);

--- a/src/content/notes/51.md
+++ b/src/content/notes/51.md
@@ -11,8 +11,6 @@ The consistency model is defined as a contract between the software (process) an
 
 ---
 
-- **Previous Note:** [50: Service Level Agreements/Indicators/Objectives - Percentiles](/notes/50/);
-- **Next Note:** [51a: Database Race Conditions](/notes/51a/);
 - **Related Note(s):**
   - [42: What to Consider While Designing a Software System](/notes/42/);
   - [DDIA: Consistency and Consensus in Distributed Systems](/books/consistency-and-consensus-in-distributed-systems/);

--- a/src/content/notes/51a.md
+++ b/src/content/notes/51a.md
@@ -15,8 +15,6 @@ updateDate: 2023-09-21
 
 ---
 
-- **Previous Note:** [51: Consistency Models in Distributed Systems Index](/notes/51/);
-- **Next Note:** [51b: Strong Consistency](/notes/51b/);
 - **Related Note(s):**
   - [55: Database Partitioning (Sharding)](/notes/55/);
   - [Understanding How Database Transactions Work](/books/understanding-how-database-transactions-work/);

--- a/src/content/notes/51b.md
+++ b/src/content/notes/51b.md
@@ -14,8 +14,6 @@ The leader might not be a leader anymore when a request comes in. That's why the
 
 ---
 
-- **Previous Note:** [51a: Database Race Conditions](/notes/51a/);
-- **Next Note:** [51c: Sequential Consistency](/notes/51c/);
 - **Related Note(s):** [Data Replication in Distributed Systems](/books/data-replication-in-distributed-systems/);
 - **Source(s):**
   - [Understanding Distributed Systems](https://understandingdistributed.systems/);

--- a/src/content/notes/51c.md
+++ b/src/content/notes/51c.md
@@ -13,8 +13,6 @@ Also, with this approach, we pin a client to a follower.
 
 ---
 
-- **Previous Note:** [51b: Strong Consistency](/notes/51b/);
-- **Next Note:** [51d: Eventual Consistency](/notes/51d/);
 - **Related Note(s):** [Data Replication in Distributed Systems](/books/data-replication-in-distributed-systems/);
 - **Source(s):**
   - [Understanding Distributed Systems](https://understandingdistributed.systems/);

--- a/src/content/notes/51d.md
+++ b/src/content/notes/51d.md
@@ -9,8 +9,6 @@ In the leader-follower data systems, if we don't pin clients to the followers, t
 
 ---
 
-- **Previous Note:** [51c: Sequential Consistency](/notes/51c/);
-- **Next Note:** [52: Personal Values](/notes/52/);
 - **Related Note(s):**
   - [DDIA: What is Replication in Distributed Systems](/books/data-replication-in-distributed-systems/);
   - [Understanding How Database Transactions Work](/books/understanding-how-database-transactions-work/);

--- a/src/content/notes/52.md
+++ b/src/content/notes/52.md
@@ -14,6 +14,4 @@ Good values are a good direction in life for better structure and time. However,
 
 ---
 
-- **Previous Note:** [51d: Eventual Consistency](/notes/51d/);
-- **Next Note:** [52a: Accepting one thing requires saying no to other things](/notes/52a/);
 - **Source(s):** [The Subtle Art of Not Giving A Fuck by Mark Manson](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);

--- a/src/content/notes/52a.md
+++ b/src/content/notes/52a.md
@@ -15,7 +15,5 @@ Saying yes and sticking to a thing requires saying no to many other things. Soci
 
 ---
 
-- **Previous Note:** [52: Personal Values](/notes/52/);
-- **Next Note:** [52b: Accepting Death Destroys Entitlement](/notes/52b/);
 - **Source(s):** [The Subtle Art of Not Giving A Fuck by Mark Manson](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);
 - **Resourced:** [One Decision That Removes Hundreds of Decisions](/decisions-that-remove-other-decisions/);

--- a/src/content/notes/52b.md
+++ b/src/content/notes/52b.md
@@ -15,6 +15,4 @@ Once we accept and always remember that we will die, we can choose not to give a
 
 ---
 
-- **Previous Note:** [52a: Accepting one thing requires saying no to other things](/notes/52a/);
-- **Next Note:** [52c: The Last Person on Earth](/notes/52c/);
 - **Source(s):** [The Subtle Art of Not Giving A Fuck by Mark Manson](/books/the-subtle-art-of-not-giving-a-fuck-by-mark-manson-book-summary-review-and-notes/);

--- a/src/content/notes/52c.md
+++ b/src/content/notes/52c.md
@@ -12,8 +12,6 @@ Understanding our values is one thing; building personality around them is anoth
 
 ---
 
-- **Previous Note:** [52b: Accepting Death Destroys Entitlement](/notes/52b/);
-- **Next Note:** [52d: Genghis Khan on Friendship](/notes/52d/);
 **Related Note(s):**
   - [1: Why do we bother to write?](/notes/1/);
   - [8: Growing in the Career](/notes/8/);

--- a/src/content/notes/52d.md
+++ b/src/content/notes/52d.md
@@ -13,8 +13,6 @@ The interesting side of Genghis Khan is how he destroys his family and tribe rel
 
 ---
 
-- **Previous Note:** [52c: The Last Person on Earth](/notes/52c/);
-- **Next Note:** [52e: Pass your words from three doors before you speak](/notes/52e/);
 - **Related Note(s):**
   - [46: Coaching Yourself](/notes/46/);
   - [44: Understanding Differences in Opinions and Perspectives](/notes/44/);

--- a/src/content/notes/52e.md
+++ b/src/content/notes/52e.md
@@ -12,8 +12,6 @@ The third door ensures you don't break hearts with your words because once a hea
 
 ---
 
-- **Previous Note:** [52d: Genghis Khan on Friendship](/notes/52d/);
-- **Next Note:** [53: Guiding Direct Reports as Manager](/notes/53/);
 - **Related Note(s):**
   - [6: Being a boss who cares personally](/notes/6/);
   - [13: Be Kind at Work](/notes/13/);

--- a/src/content/notes/53.md
+++ b/src/content/notes/53.md
@@ -12,8 +12,6 @@ Guiding someone is not always giving directions. When something is wrong, we giv
 
 ---
 
-- **Previous Note:** [52e: Pass your words from three doors before you speak](/notes/52e/);
-- **Next Note:** [53a: Not everyone has to have a passion for work](/notes/53a/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [6: Being a boss who cares personally](/notes/6/);

--- a/src/content/notes/53a.md
+++ b/src/content/notes/53a.md
@@ -13,8 +13,6 @@ Not everyone has to have a passion for work, and it's okay. If they still try th
 
 ---
 
-- **Previous Note:** [53: Guiding Direct Reports as Manager](/notes/53/);
-- **Next Note:** [53a1: Passionate people drive work better](/notes/53a1/);
 - **Related Note(s):**
   - [24: Strong teams are motivated by goals](/notes/24/);
   - [3b5: Asking Questions to Build Trust with A Direct Report](/notes/3b5/);

--- a/src/content/notes/53a1.md
+++ b/src/content/notes/53a1.md
@@ -11,8 +11,6 @@ Although passion is not required, when we find passionate people, it's so much m
 
 ---
 
-- **Previous Note:** [53a: Not everyone has to have a passion for work](/notes/53a/);
-- **Next Note:** [53b: Don't leave your best performers alone](/notes/53b/);
 - **Related Note(s):**
   - [20: Influencing Others](/notes/20/);
   - [24: Strong teams are motivated by goals](/notes/24/);

--- a/src/content/notes/53b.md
+++ b/src/content/notes/53b.md
@@ -13,8 +13,6 @@ When people perform well in their jobs, they earn autonomy. These people usually
 
 ---
 
-- **Previous Note:** [53a1: Passionate people drive work better](/notes/53a1/);
-- **Next Note:** [53c: Summarize when you want to clarify the other side's change request](/notes/53c/);
 - **Related Note(s):**
   - [3c3: Giving ownership to people by delegation](/notes/3c3/);
   - [3b1: Building Trust as a New Engineering Manager](/notes/3b1/);

--- a/src/content/notes/53c.md
+++ b/src/content/notes/53c.md
@@ -11,8 +11,6 @@ When a person wants to change something and consult us as a coach or manager, su
 
 ---
 
-- **Previous Note:** [53b: Don't leave your best performers alone](/notes/53b/);
-- **Next Note:** [53d: Listen with attention and ask questions with curiosity to encourage others to be open](/notes/53d/);
 - **Related Note(s):**
   - [15: What should you do when your manager delegates a task to you](/notes/15/);
   - [23: The First Question of Feedback Discussions](/notes/23/);

--- a/src/content/notes/53d.md
+++ b/src/content/notes/53d.md
@@ -12,8 +12,6 @@ When we listen, we give the best gift: our attention. If we take time and listen
 
 ---
 
-- **Previous Note:** [53c: Summarize when you want to clarify the other side's change request](/notes/53c/);
-- **Next Note:** [53e: Task-Relevant Maturity](/notes/53e/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [20: Influencing Others](/notes/20/);

--- a/src/content/notes/53e.md
+++ b/src/content/notes/53e.md
@@ -23,8 +23,6 @@ The last piece of the puzzle is adjusting 1:1s. When people's TRM is low, handho
 
 ---
 
-- **Previous Note:** [53d: Listen with attention and ask questions with curiosity to encourage others to be open](/notes/53d/);
-- **Next Note:** [54: Creating Open Culture at Work](/notes/54/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [4: Monitoring Work of Direct Reports](/notes/4/);

--- a/src/content/notes/54.md
+++ b/src/content/notes/54.md
@@ -16,8 +16,6 @@ Read every question and really answer all of them, address the problems. Publish
 
 ---
 
-- **Previous Note:** [53e: Task-Relevant Maturity](/notes/53e/);
-- **Next Note:** [54a: Create company values from stories in your life](/notes/54a/);
 - **Related Note(s):**
   - [3b2: Building Trust as a Leader](/notes/3b2/);
   - [36: Open Feedback Culture](/notes/36/);

--- a/src/content/notes/54a.md
+++ b/src/content/notes/54a.md
@@ -18,6 +18,4 @@ If you're interviewing a company that puts core values everywhere in public, ask
 
 ---
 
-- **Previous Note:** [54: Creating Open Culture at Work](/notes/54/);
-- **Next Note:** [54b: Culture Reflects Leadership](/notes/54b/);
 - **Source(s):** [Worth Doing Wrong by Arnie S. Malham](/books/worth-doing-wrong-book-summary-review-and-notes/);

--- a/src/content/notes/54b.md
+++ b/src/content/notes/54b.md
@@ -16,8 +16,6 @@ Invest in your culture. Make mistakes and learn from them. Make mistakes to lear
 
 ---
 
-- **Previous Note:** [54a: Create company values from stories in your life](/notes/54a/);
-- **Next Note:** [54c: Comparing Psychological Safety with Performance Culture](/notes/54c/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [24: Strong teams are motivated by goals](/notes/24/);

--- a/src/content/notes/54c.md
+++ b/src/content/notes/54c.md
@@ -15,8 +15,6 @@ On the other hand, the culture decays when performance and delivery become the f
 
 ---
 
-- **Previous Note:** [54b: Culture Reflects Leadership](/notes/54b/);
-- **Next Note:** [54d: Number One in Formula One](/notes/54d/);
 - **Related Note(s):**
   - [6: Being a boss who cares personally](/notes/6/);
   - [22: Cross-Cultural Communication](/notes/22/);

--- a/src/content/notes/54d.md
+++ b/src/content/notes/54d.md
@@ -12,8 +12,6 @@ It's a race where a millisecond can change the result. It's a race where the eng
 
 ---
 
-- **Previous Note:** [54c: Comparing Psychological Safety with Performance Culture](/notes/54c/);
-- **Next Note:** [55: Database Partitioning (Sharding)](/notes/55/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [24: Strong teams are motivated by goals](/notes/24/);

--- a/src/content/notes/55.md
+++ b/src/content/notes/55.md
@@ -15,8 +15,6 @@ There are different methods for partitioning a database.
 
 ---
 
-- **Previous Note:** [54d: Number One in Formula One](/notes/54d/);
-- **Next Note:** [55a: Vertical Partitioning](/notes/55a/);
 - **Related Note(s):**
   - [42b: Systems and Design Thinking](/notes/42b/);
   - [48: System Design Index](/notes/48/);

--- a/src/content/notes/55a.md
+++ b/src/content/notes/55a.md
@@ -9,6 +9,4 @@ Vertical Partitioning is splitting database tables into multiple tables and stor
 
 ---
 
-- **Previous Note:** [55: Database Partitioning (Sharding)](/notes/55/);
-- **Next Note:** [55b: Horizontal Partitioning (Range-Based Partitioning)](/notes/55b/);
 - **Related Note(s):** [60: Database Normalization](/notes/60/);

--- a/src/content/notes/55b.md
+++ b/src/content/notes/55b.md
@@ -9,6 +9,4 @@ In this mechanism, we use range-based partitioning. We split the data to multipl
 
 ---
 
-- **Previous Note:** [55a: Vertical Partitioning](/notes/55a/);
-- **Next Note:** [55c: Directory-Based Partitioning](/notes/55c/);
 - **Related Note(s):** [How to Partition a Database](/books/database-partitioning/);

--- a/src/content/notes/55c.md
+++ b/src/content/notes/55c.md
@@ -8,6 +8,3 @@ updateDate: 2023-09-21
 We put a lookup service in front of the database partitions. The lookup service knows the current partitioning scheme and can tell us which shard to read or update the data. Clients first communicate with the lookup service to learn which partition they must go to, then query/update the data. Using directory-based partitioning, we can add additional database servers or change the partitioning schema without impacting the application. The disadvantage of this method is that the lookup table is a single point of failure.
 
 ---
-
-- **Previous Note:** [55b: Horizontal Partitioning (Range-Based Partitioning)](/notes/55b/);
-- **Next Note:** [55d: Key-Value Partitioning (Key or Hash)](/notes/55d/);

--- a/src/content/notes/55d.md
+++ b/src/content/notes/55d.md
@@ -9,5 +9,3 @@ In hash partitioning, we use hash functions for ranges to distribute data evenly
 
 ---
 
-- **Previous Note:** [55c: Directory-Based Partitioning](/notes/55c/);
-- **Next Note:** [56: Structuring Teams in Organizations](/notes/56/);

--- a/src/content/notes/56.md
+++ b/src/content/notes/56.md
@@ -11,8 +11,6 @@ I've been in various reorgs. Sometimes, it made sense to do a re-organization to
 
 ---
 
-- **Previous Note:** [55d: Key-Value Partitioning (Key or Hash)](/notes/55d/);
-- **Next Note:** [56a: Conway's Law Still Holds True After Decades](/notes/56a/);
 - **Related Note(s):**
   - [34: Clarity in Organizations](/notes/34/);
   - [36: Open Feedback Culture](/notes/36/);

--- a/src/content/notes/56a.md
+++ b/src/content/notes/56a.md
@@ -12,8 +12,6 @@ I used to think designing systems and architectures started within the team. Eng
 
 ---
 
-- **Previous Note:** [56: Structuring Teams in Organizations](/notes/56/);
-- **Next Note:** [56b: Limiting the communication lines to create better system design](/notes/56b/);
 - **Related Note(s):**
   - [19c: How to move faster in organizations](/notes/19c/);
   - [42b: Systems and Design Thinking](/notes/42b/);

--- a/src/content/notes/56b.md
+++ b/src/content/notes/56b.md
@@ -12,8 +12,6 @@ There is an understanding that the more communication between teams and people, 
 
 ---
 
-- **Previous Note:** [56a: Conway's Law Still Holds True After Decades](/notes/56a/);
-- **Next Note:** [56b1: Define team APIs to design the team's outside communication](/notes/56b1/);
 - **Related Note(s):**
   - [48: System Design Index](/notes/48/);
   - [49: Accidental Complexity](/notes/49/);

--- a/src/content/notes/56b1.md
+++ b/src/content/notes/56b1.md
@@ -9,8 +9,6 @@ In theory, having team APIs is great and can work in relaxed times. Defining and
 
 ---
 
-- **Previous Note:** [56b: Limiting the communication lines to create better system design](/notes/56b/);
-- **Next Note:** [56c: Team Anti-Patterns and their effects](/notes/56c/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [33: Elevating Others Around You](/notes/33/);

--- a/src/content/notes/56c.md
+++ b/src/content/notes/56c.md
@@ -13,8 +13,6 @@ Shuffling team members is often called team fluidity—teams change once in a wh
 
 ---
 
-- **Previous Note:** [56b1: Define team APIs to design the team's outside communication](/notes/56b1/);
-- **Next Note:** [56d: Forming teams and defining topology depends on the context](/notes/56d/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [36: Open Feedback Culture](/notes/36/);

--- a/src/content/notes/56d.md
+++ b/src/content/notes/56d.md
@@ -9,8 +9,6 @@ The pre-maturely decided team structures often fail sooner than expected. Teams 
 
 ---
 
-- **Previous Note:** [56c: Team Anti-Patterns and their effects](/notes/56c/);
-- **Next Note:** [56d1: Organizations should reduce cognitive load on stream-aligned teams](/notes/56d1/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [32: Communicating Decisions in Organizations](/notes/32/);

--- a/src/content/notes/56d1.md
+++ b/src/content/notes/56d1.md
@@ -14,8 +14,6 @@ When other teams exist (e.g., platform), stream-aligned teams thrive and become 
 
 ---
 
-- **Previous Note:** [56d: Forming teams and defining topology depends on the context](/notes/56d/);
-- **Next Note:** [56d2: Form enabling teams to share expert knowledge in the organization](/notes/56d2/);
 - **Related Note(s):**
   - [24: Strong teams are motivated by goals](/notes/24/);
   - [33: Elevating Others Around You](/notes/33/);

--- a/src/content/notes/56d2.md
+++ b/src/content/notes/56d2.md
@@ -12,8 +12,6 @@ Enabling teams consist of experts in a subtopic where deep expertise is required
 
 ---
 
-- **Previous Note:** [56d1: Organizations should reduce cognitive load on stream-aligned teams](/notes/56d1/);
-- **Next Note:** [56d3: Separate Concerns to Relax the cognitive load by using complicated subsystem teams](/notes/56d3/);
 - **Related Note(s):**
   - [20: Influencing Others](/notes/20/);
   - [24: Strong teams are motivated by goals](/notes/24/);

--- a/src/content/notes/56d3.md
+++ b/src/content/notes/56d3.md
@@ -12,8 +12,6 @@ Using Complicated Subsystem Teams separates the complicated part to reduce the c
 
 ---
 
-- **Previous Note:** [56d2: Form enabling teams to share expert knowledge in the organization](/notes/56d2/);
-- **Next Note:** [56d4: Platform Teams](/notes/56d4/);
 - **Related Note(s):**
   - [24: Strong teams are motivated by goals](/notes/24/);
   - [34: Clarity in Organizations](/notes/34/);

--- a/src/content/notes/56d4.md
+++ b/src/content/notes/56d4.md
@@ -12,8 +12,6 @@ Getting the platform right is difficult because of the product pressure. Once th
 
 ---
 
-- **Previous Note:** [56d3: Separate Concerns to Relax the cognitive load by using complicated subsystem teams](/notes/56d3/);
-- **Next Note:** [56d4a: How to Use Platform teams In The Organization](/notes/56d4a/);
 - **Related Note(s):**
   - [50: Service Level Agreements/Indicators/Objectives - Percentiles](/notes/50/);
   - [49: Accidental Complexity](/notes/49/);

--- a/src/content/notes/56d4a.md
+++ b/src/content/notes/56d4a.md
@@ -11,9 +11,7 @@ Platform teams have a lot of organizational work besides designing and coding th
 
 ---
 
-- **Previous Note:** [56d4: Platform Teams](/notes/56d4/);
-- **Next Note:** [56e: Monoliths are everywhere](/notes/56e/);
-**Related Note(s):**
+- **Related Note(s):**
   - [39: Increasing Quality of Systems](/notes/39/);
   - [19c: How to move faster in organizations](/notes/19c/);
   - [2a: Take breaks to write better](/notes/2a/);

--- a/src/content/notes/56e.md
+++ b/src/content/notes/56e.md
@@ -9,8 +9,6 @@ I used to think of [system design](/notes/48/) as being formed by technical and 
 
 ---
 
-- **Previous Note:** [56d4a: How to Use Platform teams In The Organization](/notes/56d4a/);
-- **Next Note:** [56f: Team Interaction Modes](/notes/56f/);
 - **Related Note(s):**
   - [48: System Design Index](/notes/48/);
   - [59: Functional Decomposition in Software Systems](/notes/59/);

--- a/src/content/notes/56f.md
+++ b/src/content/notes/56f.md
@@ -9,8 +9,6 @@ When organizations are poorly managed, usually, there is chaos between teams: ei
 
 ---
 
-- **Previous Note:** [56e: Monoliths are everywhere](/notes/56e/);
-- **Next Note:** [56g: Two teams shouldn't collaborate all the time](/notes/56g/);
 - **Related Note(s):**
   - [22: Cross-Cultural Communication](/notes/22/);
   - [34: Clarity in Organizations](/notes/34/);

--- a/src/content/notes/56g.md
+++ b/src/content/notes/56g.md
@@ -9,8 +9,6 @@ Sometimes, it looks like long-term collaboration is necessary between two teams 
 
 ---
 
-- **Previous Note:** [56f: Team Interaction Modes](/notes/56f/);
-- **Next Note:** [56g1: Collaboration harms organizations](/notes/56g1/);
 - **Related Note(s):**
   - [49: Accidental Complexity](/notes/49/);
   - [44: Understanding Differences in Opinions and Perspectives](/notes/44/);

--- a/src/content/notes/56g1.md
+++ b/src/content/notes/56g1.md
@@ -11,6 +11,4 @@ Organizations mistake collaboration as a good strategy and don't see its side ef
 
 ---
 
-- **Previous Note:** [56g: Two teams shouldn't collaborate all the time](/notes/56g/);
-- **Next Note:** [56h: How I think about X-As-A-Service Teams](/notes/56h/);
 - **Source(s):** [Team Topologies by Matthew Skelton and Manuel Pais](/books/team-topologies-book-review-summary-and-notes/);

--- a/src/content/notes/56h.md
+++ b/src/content/notes/56h.md
@@ -9,8 +9,6 @@ Creating an X-as-a-service team communication mode has advantages and disadvanta
 
 ---
 
-- **Previous Note:** [56g1: Collaboration harms organizations](/notes/56g1/);
-- **Next Note:** [56i: The Teams that enable other teams](/notes/56i/);
 - **Related Note(s):**
   - [3c: Giving Ownership to People](/notes/3c/);
   - [19a: Knowns and Unknowns](/notes/19a/);

--- a/src/content/notes/56i.md
+++ b/src/content/notes/56i.md
@@ -11,6 +11,4 @@ The most difficult part of facilitating interaction mode is to create an [enabli
 
 ---
 
-- **Previous Note:** [56h: How I think about X-As-A-Service Teams](/notes/56h/);
-- **Next Note:** [56i1: Facilitating Teams in Organizations](/notes/56i1/);
 - **Source(s):** [Team Topologies by Matthew Skelton and Manuel Pais](/books/team-topologies-book-review-summary-and-notes/);

--- a/src/content/notes/56i1.md
+++ b/src/content/notes/56i1.md
@@ -9,6 +9,4 @@ Having facilitating team interaction mode should be across the organization. I t
 
 ---
 
-- **Previous Note:** [56i: The Teams that enable other teams](/notes/56i/);
-- **Next Note:** [56j: Setting the environment for team interactions to work](/notes/56j/);
 - **Source(s):** [Team Topologies by Matthew Skelton and Manuel Pais](/books/team-topologies-book-review-summary-and-notes/);

--- a/src/content/notes/56j.md
+++ b/src/content/notes/56j.md
@@ -9,8 +9,6 @@ For [team interaction modes](/notes/56f/) to work, managers have to work on crea
 
 ---
 
-- **Previous Note:** [56i1: Facilitating Teams in Organizations](/notes/56i1/);
-- **Next Note:** [56k: Inverse Conway Maneuver gets help from team interaction modes and team types to succeed](/notes/56k/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [3b1: Building Trust as a New Engineering Manager](/notes/3b1/);

--- a/src/content/notes/56k.md
+++ b/src/content/notes/56k.md
@@ -9,8 +9,6 @@ updateDate: 2023-09-22
 
 ---
 
-- **Previous Note:** [56j: Setting the environment for team interactions to work](/notes/56j/);
-- **Next Note:** [56l: Team Design Rules](/notes/56l/);
 - **Related Note(s):**
   - [48: System Design Index](/notes/48/);
   - [43: The Role and Responsibility of Software Architect](/notes/43/);

--- a/src/content/notes/56l.md
+++ b/src/content/notes/56l.md
@@ -13,7 +13,5 @@ If two teams need to collaborate, how long should it be? What should be the next
 
 ---
 
-- **Previous Note:** [56k: Inverse Conway Maneuver gets help from team interaction modes and team types to succeed](/notes/56k/);
-- **Next Note:** [57: Diseconomy of Scale](/notes/57/);
 - **Related Note(s):** [30a: Change is Inevitable](/notes/30a/);
 - **Source(s):** [Team Topologies by Matthew Skelton and Manuel Pais](/books/team-topologies-book-review-summary-and-notes/);

--- a/src/content/notes/57.md
+++ b/src/content/notes/57.md
@@ -9,8 +9,6 @@ The size of the project matters a lot in the diseconomy of scale. In Software Es
 
 ---
 
-- **Previous Note:** [56l: Team Design Rules](/notes/56l/);
-- **Next Note:** [58: Scalability in Software Systems](/notes/58/);
 - **Related Note(s):**
   - [2e: Elements of a Story](/notes/2e/);
   - [49: Accidental Complexity](/notes/49/);

--- a/src/content/notes/58.md
+++ b/src/content/notes/58.md
@@ -44,8 +44,6 @@ How does it work in Microservices architecture? Read the [Building Microservices
 
 ---
 
-- **Previous Note:** [57: Diseconomy of Scale](/notes/57/);
-- **Next Note:** [58a: Defining System Load](/notes/58a/)
 - **Related Note(s):**
   - [48: System Design Index](/notes/48/);
   - [55: Database Partitioning (Sharding)](/notes/55/);

--- a/src/content/notes/58a.md
+++ b/src/content/notes/58a.md
@@ -11,6 +11,4 @@ When we think about Twitter, the load parameter is not how many tweets are poste
 
 ---
 
-- **Previous Note:** [58: Scalability in Software Systems](/notes/58/);
-- **Next Note:** [58b: Defining System Performance](/notes/58b/);
 - **Source(s):** Designing Data-Intensive Applications by Martin Kleppmann

--- a/src/content/notes/58b.md
+++ b/src/content/notes/58b.md
@@ -24,6 +24,4 @@ Now that we understand how we can describe performance and load, we can define S
 
 ---
 
-- **Previous Note:** [58a: Defining System Load](/notes/58a/);
-- **Next Note:** [58c: Approaches for Coping with Increased Load in Software Systems](/notes/58c/);
 - **Source(s):** Designing Data-Intensive Applications by Martin Kleppmann

--- a/src/content/notes/58c.md
+++ b/src/content/notes/58c.md
@@ -15,7 +15,5 @@ In start-ups and non-proven products, it's more important to iterate on the prod
 
 ---
 
-- **Previous Note:** [58b: Defining System Performance](/notes/58b/);
-- **Next Note:** [58d: Pros and Cons of Vertical Scaling (Scaling Up)](/notes/58d/);
 - **Related Note(s):** [48d: Elasticity in Software Systems](/notes/48d/);
 - **Source(s):** Designing Data-Intensive Applications by Martin Kleppmann

--- a/src/content/notes/58d.md
+++ b/src/content/notes/58d.md
@@ -20,6 +20,3 @@ Increasing the size of the instances and, for example, increasing the server's m
 - Single point of failure.
 
 ---
-
-- **Previous Note:** [58c: Approaches for Coping with Increased Load in Software Systems](/notes/58c/);
-- **Next Note:** [59: Functional Decomposition in Software Systems](/notes/59/);

--- a/src/content/notes/59.md
+++ b/src/content/notes/59.md
@@ -29,6 +29,3 @@ If you want to expand your knowledge in splitting monolith to microservices, I r
 If you want to expand your knowledge in scaling mobile apps, I recommend reading Building Mobile Apps at Scale by Gergely Orosz. Although the book is not a technical deep dive, it gives great insights into the challenges you will face.
 
 ---
-
-- **Previous Note:** [58d: Pros and Cons of Vertical Scaling (Scaling Up)](/notes/58d/);
-- **Next Note:** [60: Database Normalization](/notes/60/);

--- a/src/content/notes/5a.md
+++ b/src/content/notes/5a.md
@@ -13,6 +13,4 @@ People who grew quickly but have struggled in their position perform badly becau
 
 ---
 
-- **Previous Note:** [5: Managing Promotions](/notes/5/);
-- **Next Note:** [5b: Different People have different growth trajectories](/notes/5b/);
 - **Source(s):** Radical Candor by Kim Scott

--- a/src/content/notes/5b.md
+++ b/src/content/notes/5b.md
@@ -13,8 +13,6 @@ Identifying each person and understanding their desire is vital. That's why inst
 
 ---
 
-- **Previous Note:** [5a: Why people who are growing too fast can have low performance](/notes/5a/);
-- **Next Note:** [6: Being a boss who cares personally](/notes/6/);
 - **Related Note(s):**
   - [8: Growing in the Career](/notes/8/);
   - [23: The First Question of Feedback Discussions](/notes/23/);

--- a/src/content/notes/6.md
+++ b/src/content/notes/6.md
@@ -14,7 +14,5 @@ Many leaders mix these two and think of the word boss as something negative beca
 
 ---
 
-- **Previous Note:** [5b: Different People have different growth trajectories](/notes/5b/);
-- **Next Note:** [7: Confident Humility](/notes/7/);
 - **Related Note(s):** [23b1: Be careful with obnoxious aggression](/notes/23b1/);
 - **Source(s):** Radical Candor by Kim Scott

--- a/src/content/notes/60.md
+++ b/src/content/notes/60.md
@@ -12,6 +12,3 @@ Database denormalization means adding redundant information into a database to s
 When the databases grow, join operations become slower. To avoid this, we either use denormalization or NoSQL. NoSQL is designed differently and has no join operation.
 
 ---
-
-- **Previous Note:** [59: Functional Decomposition in Software Systems](/notes/59/);
-- **Next Note:** [61: What to delegate?](/notes/61/);

--- a/src/content/notes/61.md
+++ b/src/content/notes/61.md
@@ -16,6 +16,4 @@ Things to delegate:
 
 ---
 
-- **Previous Note:** [60: Database Normalization](/notes/60/);
-- **Next Note:** [61a: Who to delegate the work?](/notes/61a/);
 - **Related Note(s):** [3c: Giving Ownership to People](/notes/3c/);

--- a/src/content/notes/61a.md
+++ b/src/content/notes/61a.md
@@ -17,7 +17,5 @@ When deciding the person you're going to delegate the work, look for specific cr
 
 ---
 
-- **Previous Note:** [61: What to delegate?](/notes/61/);
-- **Next Note:** [62: Energy Management at Work](/notes/62/);
 - **Related Note(s):** [3c3: Giving ownership to people by delegation](/notes/3c3/);
 - **Source(s):** My mentor, in one of our 1:1 sessions, I asked him how I could decide to whom I would delegate the work.

--- a/src/content/notes/62.md
+++ b/src/content/notes/62.md
@@ -15,8 +15,6 @@ Your energy levels are insufficient, and you cannot run the club sustainably. Th
 
 ---
 
-- **Previous Note:** [61a: Who to delegate the work?](/notes/61a/);
-- **Next Note:** [62a: Resilience comes from recovery](/notes/62a/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [61: What to delegate?](/notes/61/);

--- a/src/content/notes/62a.md
+++ b/src/content/notes/62a.md
@@ -16,8 +16,6 @@ We can see the same in weightlifting. If you need to do three sets of ten repeti
 
 ---
 
-- **Previous Note:** [62: Energy Management at Work](/notes/62/);
-- **Next Note:** [63: How cultures are shaped in the world](/notes/63/);
 - **Related Note(s):**
   - [8: Growing in the Career](/notes/8/);
   - [11: How to move to the next level](/notes/11/);

--- a/src/content/notes/63.md
+++ b/src/content/notes/63.md
@@ -18,8 +18,6 @@ How Maathai perceives her childhood and culture is impressive. It's often imposs
 
 ---
 
-- **Previous Note:** [62a: Resilience comes from recovery](/notes/62a/);
-- **Next Note:** [64: Why Inspectional Reading?](/notes/64/);
 - **Related Note(s):**
   - [27: Developing Habits](/notes/27/);
   - [52: Personal Values](/notes/52/);

--- a/src/content/notes/64.md
+++ b/src/content/notes/64.md
@@ -12,7 +12,6 @@ The questions that we need to answer after inspectional reading shows how much w
 
 ---
 
-- **Next Note:** [65: Learning and Understanding](/notes/65/);
 - **Related Note(s):**
   - [39: Increasing Quality of Systems](/notes/39/);
   - [65: Learning and Understanding](/notes/65/);

--- a/src/content/notes/65.md
+++ b/src/content/notes/65.md
@@ -14,8 +14,6 @@ When we come across information, we mistakenly think we have learned something n
 
 ---
 
-- **Previous Note:** [64: Why Inspectional Reading?](/notes/64/);
-- **Next Note:** [66: RFC Process in Organizations](/notes/66/);
 - **Related Note(s):**
   - [1: Why do we bother to write?](/notes/1/);
   - [54: Creating Open Culture at Work](/notes/54/);

--- a/src/content/notes/66.md
+++ b/src/content/notes/66.md
@@ -15,8 +15,6 @@ Many mid-to-big organizations later aim to create governance around the RFC proc
 
 ---
 
-- **Previous Note:** [65: Learning and Understanding](/notes/65/);
-- **Next Note:** [66a: If there is no business need, there shouldn't be an RFC](/notes/66a/);
 - **Related Note(s):**
   - [61: What to delegate?](/notes/61/);
   - [56: Structuring Teams in Organizations](/notes/56/);

--- a/src/content/notes/66a.md
+++ b/src/content/notes/66a.md
@@ -15,8 +15,6 @@ If there is no business need for an idea, there shouldn't be an RFC. When I say 
 
 ---
 
-- **Previous Note:** [66: RFC Process in Organizations](/notes/66/);
-- **Next Note:** [66b: No Prioritization, No RFC](/notes/66b/);
 - **Related Note(s):**
   - [12: Engineer Autonomy](/notes/12/);
   - [34: Clarity in Organizations](/notes/34/);

--- a/src/content/notes/66b.md
+++ b/src/content/notes/66b.md
@@ -15,8 +15,6 @@ For RFC to serve well, the solution has to be prioritized correctly. If a team c
 
 ---
 
-- **Previous Note:** [66a: If there is no business need, there shouldn't be an RFC](/notes/66a/);
-- **Next Note:** [66c: Don't Use RFCs as A Decision-Making Mechanism](/notes/66c/);
 - **Related Note(s):**
   - [29: Uncertainty is needed to stay open-minded](/notes/29/);
   - [34: Clarity in Organizations](/notes/34/);

--- a/src/content/notes/66c.md
+++ b/src/content/notes/66c.md
@@ -14,8 +14,6 @@ An RFC can't drive a business decision; however, it can bring out risks that wer
 
 ---
 
-- **Previous Note:** [66b: No Prioritization, No RFC](/notes/66b/);
-- **Next Note:** [66d: Don't Even Try to Form A Consensus](/notes/66d/);
 - **Related Note(s):**
   - [19b: Consent-Based Decision Making](/notes/19b/);
   - [20: Influencing Others](/notes/20/);

--- a/src/content/notes/66d.md
+++ b/src/content/notes/66d.md
@@ -13,8 +13,6 @@ There is no need to form a consensus for every topic. The RFC system works with 
 
 ---
 
-- **Previous Note:** [66c: Don't Use RFCs as A Decision-Making Mechanism](/notes/66c/);
-- **Next Note:** [66e: Choose Your RFC Audience Correctly](/notes/66e/);
 - **Related Note(s):**
   - [19b: Consent-Based Decision Making](/notes/19b/);
   - [52a: Accepting one thing requires saying no to other things](/notes/52a/);

--- a/src/content/notes/66e.md
+++ b/src/content/notes/66e.md
@@ -11,8 +11,6 @@ Not every RFC has to be shared with the whole company. Push RFCs to related peop
 
 ---
 
-- **Previous Note:** [66d: Don't Even Try to Form A Consensus](/notes/66d/);
-- **Next Note:** [66f: Give Enough Time for RFC Reviews (Please, Don't Rush)](/notes/66f/);
 - **Related Note(s):**
   - [32b: Communicating Organizational Changes](/notes/32b/);
   - [43: The Role and Responsibility of Software Architect](/notes/43/);

--- a/src/content/notes/66f.md
+++ b/src/content/notes/66f.md
@@ -13,6 +13,4 @@ Of course, it depends on the RFC. If an RFC is circulating in one team, it's oka
 
 ---
 
-- **Previous Note:** [66e: Choose Your RFC Audience Correctly](/notes/66e/);
-- **Next Note:** [66g: Don't Publish The RFC and Forget; Follow Up](/notes/66g/);
 - **Resourced:** [How and Why RFCs Fail](/how-and-why-rfcs-fail/);

--- a/src/content/notes/66g.md
+++ b/src/content/notes/66g.md
@@ -15,8 +15,6 @@ Give people signs regularly on when you'll close it for feedback. Be proactive. 
 
 ---
 
-- **Previous Note:** [66f: Give Enough Time for RFC Reviews (Please, Don't Rush)](/notes/66f/);
-- **Next Note:** [66h: Don't Build an Extensive RFC Template](/notes/66h/);
 - **Related Note(s):**
   - [32a: Continually and consistently repeat the message](/notes/32a/);
   - [3b: Joining A Team As A New Manager](/notes/3b/);

--- a/src/content/notes/66h.md
+++ b/src/content/notes/66h.md
@@ -15,6 +15,4 @@ I still recommend the NABC Model (Need, Approach, Benefits, Competitors) that St
 
 ---
 
-- **Previous Note:** [66g: Don't Publish The RFC and Forget; Follow Up](/notes/66g/);
-- **Next Note:** [66i: Build The Right Culture First Before RFCs](/notes/66i/);
 - **Resourced:** [How and Why RFCs Fail](/how-and-why-rfcs-fail/);

--- a/src/content/notes/66i.md
+++ b/src/content/notes/66i.md
@@ -16,8 +16,6 @@ Get your culture right, and people will naturally bring the RFC process by thems
 
 ---
 
-- **Previous Note:** [66h: Don't Build an Extensive RFC Template](/notes/66h/);
-- **Next Note:** [67: Seek Inconvenience](/notes/67/);
 - **Related Note(s):**
   - [54: Creating Open Culture at Work](/notes/54/);
   - [44c: Confrontation brings honesty](/notes/44c/);

--- a/src/content/notes/67.md
+++ b/src/content/notes/67.md
@@ -24,8 +24,6 @@ Look at your life; find where you shouldn't need comfort and convenience. Seek i
 
 ---
 
-- **Previous Note:** [66i: Build The Right Culture First Before RFCs](/notes/66i/);
-- **Next Note:** [68: Thinking Retrospectively Helps to Correct The Course](/notes/68/);
 - **Related Note(s):**
   - [1b: Writing by Hand](/notes/1b/);
   - [1i: Embrace & Love Boredom](/notes/1i/);

--- a/src/content/notes/68.md
+++ b/src/content/notes/68.md
@@ -15,8 +15,6 @@ I'm unsure how much it holds true, but we gain a lot of advantages from retrospe
 
 ---
 
-- **Previous Note:** [67: Seek Inconvenience](/notes/67/);
-- **Next Note:** [69: Reading and Criticizing with Enough Generosity](/notes/69/);
 - **Related Note(s):**
   - [31a: Create Accountability Cadence](/notes/31a/);
   - [38b: Behaviors run on Auto-pilot](/notes/38b/);

--- a/src/content/notes/69.md
+++ b/src/content/notes/69.md
@@ -15,8 +15,6 @@ Molly also talks about reading critically and compares it with bad faith reading
 
 ---
 
-- **Previous Note:** [68: Thinking Retrospectively Helps to Correct The Course](/notes/68/);
-- **Next Note:** [70: Why Urban Design Matters](/notes/70/);
 - **Related Note(s):**
   - [64: Why Inspectional Reading?](/notes/64/);
 - **Source:** [On Learning to Read Generously](https://www.tor.com/2023/08/10/on-learning-to-read-generously/);

--- a/src/content/notes/69a.md
+++ b/src/content/notes/69a.md
@@ -1,0 +1,16 @@
+---
+title: "LLMs = Ignorance"
+zettelId: "69a"
+tags:
+  - barriers-to-learning
+  - simplifying-ideas
+date: 2024-11-20T16:23:33.014Z
+updateDate: 2024-11-20T16:23:33.014Z
+draft: false
+---
+
+The TV and search engines [made](/notes/68/) people think less. They killed [intellectual curiosity](/notes/30/). Constant access to information that nobody needs pushes people away from [fulfilling their curiosity by research](/notes/65/). LLM took this to another level. People trusting AI, the closed and opaque box, is [breaking society apart](/notes/63/) by [making people ignorant](/notes/38/). People don't [validate the information](/notes/64/) and follow it. They [form opinions without correct information](/notes/73/). LLM is revolutionary, and there is nothing that will stop it until it's too late. We should adopt LLM into our lives for sure. But should we trust? [Hell, no](/notes/67/)!
+
+---
+
+- **Sources:** Thoughts after the Keynote talk in CTO Craft Con: Berlin 2024: Keynote — The Role of AI in Shaping Future Workplaces

--- a/src/content/notes/7.md
+++ b/src/content/notes/7.md
@@ -12,8 +12,6 @@ When I think about managers I've worked with, the best ones were the ones who sa
 
 ---
 
-- **Previous Note:** [7: Confident Humility](/notes/7/);
-- **Next Note:** [8: Growing in the Career](/notes/8/);
 - **Related Note(s):**
   - [3b1: Building Trust as a New Engineering Manager](/notes/3b1/);
   - [32: Communicating Decisions in Organizations](/notes/32/);

--- a/src/content/notes/70.md
+++ b/src/content/notes/70.md
@@ -16,6 +16,4 @@ I don't want to believe in this statement. Yet, my ignorance of the topic pushes
 
 ----
 
-- **Previous Note:** [69: Reading and Criticizing with Enough Generosity](/notes/69/);
-- **Next Note:** [71: Defining Transparency in Organizations](/notes/71/);
 - **Source:** [Monocle's March issue (#171)](https://monocle.com/magazine/issues/171/)

--- a/src/content/notes/71.md
+++ b/src/content/notes/71.md
@@ -18,8 +18,6 @@ The benefits are also cumulative: people spend less time building trust with eac
 
 ----
 
-- **Previous Note:** [70: Why Urban Design Matters](/notes/70/);
-- **Next Note:** [71a: Good and Bad Transparency in Organizations](/notes/71a/);
 - **Related Note(s):**
   - [3a: Team Decision Deployment Strategies](/notes/3a/);
   - [7: Confident Humility](/notes/7/);

--- a/src/content/notes/71a.md
+++ b/src/content/notes/71a.md
@@ -14,8 +14,6 @@ The main goal for transparency should be answering the questions before they ari
 
 ---
 
-- **Previous Note:** [71: Defining Transparency in Organizations](/notes/71/);
-- **Next Note:** [72: Increasing Sales Through Human Psychology](/notes/72/);
 - **Related Note(s):**
   - [7: Confident Humility](/notes/7/);
   - [12a: Making decisions based on three groups](/notes/12a/);

--- a/src/content/notes/72.md
+++ b/src/content/notes/72.md
@@ -9,8 +9,8 @@ In my experience, my Moonlander keyboard was broken, and I asked for support to 
 
 This rule is so strong and instinctually known by many sellers they always use it. For example, we have various stalls we go to nearby farmer’s markets. And they always add one or two gifts without us asking. Later on, we found out that we went there even more and started buying some other products, too. While they are easily exploiting the rule, I’m happily going there because every time, I get yet another gift.
 
-- **Previous Note:** [71a: Good and Bad Transparency in Organizations](/notes/71a/);
-- **Next Note:** [73: Selective Learning](/notes/73/);
+---
+
 - **Related Note(s):**
   - [20: Influencing Others](/notes/20/);
   - [37: Setting Organizational Goals and Processes](/notes/37/);

--- a/src/content/notes/73.md
+++ b/src/content/notes/73.md
@@ -15,8 +15,8 @@ updateDate: 2024-06-10
 The things we read shape how we see the world. The books, articles, or newspapers we read are the words of others; they open someone else’s world. If we’re not careful of what we consume, we may let immoral or trivial ideas affect us. Especially when we’re writing—[shaping our thoughts](/why-is-writing-important/)—others’ ideas will influence ours. And in turn, our text will influence our readers.
 The information we receive every day also comes at a cost. Selective learning is the challenge of our modern world. We can’t, and shouldn’t, turn all the information we receive into a piece of knowledge. We have to be picky and discard 99% of the information around us, especially what people call [the latest ones](/no-more-debate-with-latest-or-daily-news/). Then, we must discard the 99% of the remaining 1%. Only the remaining ideas will be worth knowing.
 
-- **Previous Note:** [72: Increasing Sales Through Human Psychology](/notes/72/);
-- **Next Note:** [74: Integrating Deep Work into Manager’s Life](/notes/74/);
+---
+
 - **Related Note(s):**
   - [2: How to Improve Writing](/notes/2/);
   - [20b: Sharing knowledge is not a noise](/notes/20b/);

--- a/src/content/notes/73a.md
+++ b/src/content/notes/73a.md
@@ -1,0 +1,15 @@
+---
+zettelId: "73a"
+title: "LLM shouldn't be used for learning"
+tags:
+  - how-to-learn
+date: 2024-11-20
+updateDate: 2024-11-20
+---
+
+
+TV changed the world in a way we can’t imagine. In the long term, we can see how much people trust what they see on TV. It became a single source of information for many as it changed [people's habits](/notes/27/). The Internet did the same. It took decades, but it steadily got its place to provide information. LLM is the next but the most problematic one. With each invention, people lost intellectuality. They trust whatever they see. The difference between LLM and the other two is that LLM is not able [to know the source of truth](/notes/30/). There is no way to validate the truth of output. That’s why it can’t be used in [learning](/notes/65/). You have to [stay skeptical and research to validate](/notes/69/).
+
+---
+
+**Source(s):** Thoughts after the Keynote talk in CTO Craft Con: Berlin 2024: Keynote – The Role of AI in Shaping Future Workplaces

--- a/src/content/notes/74.md
+++ b/src/content/notes/74.md
@@ -6,7 +6,7 @@ tags:
   - productivity
   - management-handbook
   - how-to-manage-yourself
-date: 2024-10-27T15:57:08.337Z
+date: 2024-07-26T15:57:08.337Z
 updateDate: 2024-10-27T15:57:08.337Z
 ---
 
@@ -19,8 +19,8 @@ I keep thinking about what I want from this world or my life. Yet, I also ponder
 If there is an activity where I can feel satisfied, immense in deep work, work on a better schedule (than many meetings every day), and don’t commute, it becomes easier to do deep work and not count myself as busy. Then the rest can be a real rest and I can also have idle time that I replenish my energy. Instead of a curse, I can embrace and enjoy busyness and even keep myself very active in it.
 :::
 
-- **Previous Note:** [73: Selective Learning](/notes/73/);
-- **Next Note:** [75: Understanding Ex-pat life and discrimination](/notes/75/);
+---
+
 - **Related Note(s):**
   - [3: Management Craft](/notes/3/);
   - [16a: The Meetings of a Manager](/notes/16a/);

--- a/src/content/notes/75.md
+++ b/src/content/notes/75.md
@@ -13,6 +13,3 @@ updateDate: 2024-10-27T15:57:08.337Z
 Discrimination is hidden in seemingly small, invisible daily interactions. A short police control in an international airport, a small chat in a government office, a short look of a local in the public transport. I know that it’s natural to have these uncontrolled moments. We’re tend to identify the foreigner or outsider. This mechanism is built over thousands of years; it helped human race to survive. And the modern world is going against all our habitual patterns and tells us not do identify others as foreigners. That’s the root of our struggles as a community and species. We have to change, much quicker than the evolutionary speed—thousands of times quicker.
 Yet, it looks like we’re note only changing towards a better or bright future, but more going backwards and getting beaten up by primal instincts. Everywhere, the right extremists are gaining power these days.
 This is not the first time in history this happened. We only see when we look holistically. Every few hundred years, the history repeats, a bit differently each time (that’s what makes it interesting too). But the underlying approach or events are the same.
-
-- **Previous Note:** [74: Integrating Deep Work into Manager’s Life](/notes/74/);
-- **Next Note:** [76: Becoming a CTO](/notes/76/);

--- a/src/content/notes/76.md
+++ b/src/content/notes/76.md
@@ -14,8 +14,8 @@ CTOs are now expected to know how to run a business, including finance, product 
 
 The most significant impact of this change requires CTOs to do more on people transformation, structure and roles, managing and skilling up talent, hiring, and transforming processes.
 
-- **Previous Note:** [75: Understanding Ex-pat life and discrimination](/notes/75/);
-- **Next Note:** [77: Meeting Facilitation Techniques](/notes/77/);
+---
+
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [8: Growing in the Career](/notes/8/);

--- a/src/content/notes/77.md
+++ b/src/content/notes/77.md
@@ -14,8 +14,8 @@ As a meeting facilitator, your first job is connecting people before presenting 
 
 Connection works best when people are face-to-face. If you’re hosting a workshop, use card games like [Ask Deep Questions](https://www.jankeck.com/product/adq-single/) or [We! Connect Cards](https://weand.me/product/we-connect-cards/).
 
-- **Previous Note:** [76: Becoming a CTO](/notes/76/);
-- **Next Note:** [77a: What I Need From You Matrix](/notes/77a/);
+---
+
 - **Related Note(s):**
   - [17: Public Speaking and Improving Skills](/notes/17/);
   - [53: Guiding Direct Reports as Manager](/notes/53/);

--- a/src/content/notes/77a.md
+++ b/src/content/notes/77a.md
@@ -18,8 +18,8 @@ When you’re hosting a workshop to resolve collaboration problems between teams
 
 The matrix allow each team (or person) to voice their needs from others. The goal is bringing clarity to expectations and aligning everyone.
 
-- **Previous Note:** [77: Meeting Facilitation Techniques](/notes/77/);
-- **Next Note:** [77b: Lightning Decision Jam](/notes/77b/);
+---
+
 - **Related Note(s):**
   - [20: Influencing Others](/notes/20/);
   - [22: Cross-Cultural Communication](/notes/22/);

--- a/src/content/notes/77b.md
+++ b/src/content/notes/77b.md
@@ -10,8 +10,8 @@ updateDate: 2024-10-27T15:57:08.337Z
 
 When you need to make a fast decision as a group, you can host lightning decision jam sessions. Phrase the problems you’re facing in “How Might We (HMW)” format, and ask everyone to write their answers silently into post-its. Then everyone puts their post-its to the wall and we prioritize the solutions and talk about them one by one.
 
-- **Previous Note:** [77a: What I Need From You Matrix](/notes/77a/);
-- **Next Note:** [78: Using Engineering Metrics](/notes/78/);
+---
+
 - **Related Note(s):**
   - [17: Public Speaking and Improving Skills](/notes/17/);
   - [19: Decision-Making Strategies](/notes/19/);

--- a/src/content/notes/78.md
+++ b/src/content/notes/78.md
@@ -10,8 +10,8 @@ updateDate: 2024-10-27T15:57:08.337Z
 
 Engineering metrics should live with business metrics in the same system, not in another system. Engineering metrics are part of business metrics and they have to live together. These metrics shouldn’t stay in a system where only engineering leaders can access.
 
-- **Previous Note:** [77b: Lightning Decision Jam](/notes/77b/);
-- **Next Note:** [78a: Tracking Capacity Allocation](/notes/78a/);
+---
+
 - **Related Note(s):**
   - [4: Monitoring Work of Direct Reports](/notes/4/);
   - [4b: Monitoring & Inspection to Learn](/notes/4b/);

--- a/src/content/notes/78a.md
+++ b/src/content/notes/78a.md
@@ -10,8 +10,8 @@ updateDate: 2024-10-27T15:57:08.337Z
 
 Track capacity allocation in retrospective rather than for future. This way you know what the team spent time on the last month(s). Categorize the work in three categories: tech debt, product improvements, and new features. Once you accumulate some data around how much time the team(s) spend on each category, you can bring clarity to the business around what the team is dealing with and the data can help you identify problematic areas where engineers spent a lot of time on tech debt.
 
-- **Previous Note:** [78: Using Engineering Metrics](/notes/78/);
-- **Next Note:** [79: Managing Tech Debt](/notes/79/);
+---
+
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [4: Monitoring Work of Direct Reports](/notes/4/);

--- a/src/content/notes/79.md
+++ b/src/content/notes/79.md
@@ -9,8 +9,8 @@ updateDate: 2024-10-27T15:57:08.337Z
 
 In all engineering problems like tech debt, focus on business case first. Telling executives (like CEO) or product management that tech debt has to be worked on will not work. You have to understand the business first and then find the impact of tech debt to the business. If people are complaining that the team speed is slow, find out why. Is it because of the tech debt or because of the lacking capabilities around continuous delivery. Once you found it, explain the problem’s impact to the business with clear impact evaluation and how you’ll make it better and how people will track that it gets better. Don’t start from the tech debt and explaining that you need time; it won’t work.
 
-- **Previous Note:** [78a: Tracking Capacity Allocation](/notes/78a/);
-- **Next Note:** [80: What affects your investment decision](/notes/80/);
+---
+
 - **Related Note(s):**
   - [26: The Cost of Software Deployment and Continuous Delivery](/notes/26/);
   - [39: Increasing Quality of Systems](/notes/39/);

--- a/src/content/notes/8.md
+++ b/src/content/notes/8.md
@@ -11,8 +11,6 @@ If you want to grow in your career, focus on the profession, not the title. Titl
 
 ---
 
-- **Previous Note:** [7: Confident Humility](/notes/7/);
-- **Next Note:** [8a: Making the decision between management or IC Leadership](/notes/8a/);
 - **Related Note(s):**
   - [25: Consistent writing brings success](/notes/25/);
   - [3b1: Building Trust as a New Engineering Manager](/notes/3b1/);

--- a/src/content/notes/80.md
+++ b/src/content/notes/80.md
@@ -11,7 +11,6 @@ When making investment decision, try to understand why. Do you like someone work
 
 ---
 
-- **Previous Note:** [79: Managing Tech Debt](/notes/79/);
 - **Related Note(s):**
   - [20: Influencing Others](/notes/20/);
   - [72: Increasing Sales Through Human Psychology](/notes/72/);

--- a/src/content/notes/81.md
+++ b/src/content/notes/81.md
@@ -1,0 +1,24 @@
+---
+zettelId: "81"
+title: "Improving Team Performance"
+tags:
+  - how-best-performers-become-the-best
+  - management-handbook_performance-management
+updateDate: 2024-11-22T00:00:00.000Z
+date: 2024-11-22T00:00:00.00Z
+---
+
+[According to](/notes/78/) the DORA 2024 Report:
+> Organizations that prioritize the end-user experience produce higher quality products, with developers who are more productive, satisfied, and less likely to experience burnout.
+
+[User centricity](/notes/42/) increases productivity, job satisfaction, team performance, and product performance while reducing burnout.
+Teams that understand users' needs gain fulfillment and job satisfaction when they solve user problems. In the survey, respondents explained what keeps them motivated and satisfied at their jobs. Answers show that helping users or others and knowing the solution they produce will solve someone's problem improves motivation and satisfaction, resulting in higher team performance.
+
+----
+
+- **Related Note(s):**
+  - [Management craft](/notes/3/) requires understanding where to invest time/energy.
+  - [Defining quality goals](/notes/24/) with a user-centric mindset can help improve performance even further.
+  - [While structuring teams](/notes/56/), it's crucial to adopt a user-first mindset in all types of teams, including [platform](/notes/56d4/) and [stream-aligned teams](/notes/56d1/).
+  - [While monitoring the work of the team](/notes/4/) on various levels, don't forget to include the user-centric mindset.
+- **Sources:** 2024 Final DORA Report

--- a/src/content/notes/8a.md
+++ b/src/content/notes/8a.md
@@ -14,8 +14,6 @@ You need leadership experience in both management and IC track. So, focus on you
 
 ---
 
-- **Previous Note:** [8: Growing in the Career](/notes/8/);
-- **Next Note:** [8b: Advice to Juniors](/notes/8b/);
 - **Related Note(s):**
   - [8: Growing in the Career](/notes/8/);
   - [9a: Why you are not a senior](/notes/9a/);

--- a/src/content/notes/8b.md
+++ b/src/content/notes/8b.md
@@ -11,8 +11,6 @@ Being able to write is crucial. Both technical and non-technical writing is unav
 
 ---
 
-- **Previous Note:** [8a: Making the decision between management or IC Leadership](/notes/8a/);
-- **Next Note:** [8c: Learn The Principles](/notes/8c/);
 - **Related Note(s):**
   - [1: Why do we bother to write?](/notes/1/);
   - [11: How to move to the next level](/notes/11/);

--- a/src/content/notes/8c.md
+++ b/src/content/notes/8c.md
@@ -9,8 +9,6 @@ Learn what's going on behind the scene. Learn the principles of frameworks. Why 
 
 ---
 
-- **Previous Note:** [8b: Advice to Juniors](/notes/8b/);
-- **Next Note:** [8d: Ask Questions](/notes/8d/);
 - **Related Note(s):**
   - [12: Engineer Autonomy](/notes/12/);
   - [21: Efficient Code Review Process (The changes I wanted to do in one of my teams)](/notes/21/);

--- a/src/content/notes/8d.md
+++ b/src/content/notes/8d.md
@@ -9,6 +9,4 @@ Don't be afraid of asking questions. Ask all of your questions to understand cle
 
 ---
 
-- **Previous Note:** [8c: Learn The Principles](/notes/8c/);
-- **Next Note:** [8e: Teach Others](/notes/8e/);
 - **Related Note(s):** [8i: Don't stop asking questions](/notes/8i/);

--- a/src/content/notes/8e.md
+++ b/src/content/notes/8e.md
@@ -8,6 +8,3 @@ updateDate: 2023-09-13
 When someone tries to teach something to another person, they find out missing knowledge about the topic. They learn better. The framework you teach doesn't matter. You can record a screencast, write a blog, or give a talk, it doesn't matter. And even you don't have to publish these. Just prepare them like you're gonna publish them. By doing this, you'll learn a lot of details about the topic you are working on.
 
 ---
-
-- **Previous Note:** [8d: Ask Questions](/notes/8d/);
-- **Next Note:** [8f: Seniority is not about being smarter](/notes/8f/);

--- a/src/content/notes/8f.md
+++ b/src/content/notes/8f.md
@@ -8,6 +8,3 @@ updateDate: 2023-09-13
 Seniority is not about being smarter. Senior engineers are not smarter than you. They only have more experience and they faced and solved varying problems.
 
 ---
-
-- **Previous Note:** [8e: Teach Others](/notes/8e/);
-- **Next Note:** [8g: It's not about the number of languages you know](/notes/8g/);

--- a/src/content/notes/8g.md
+++ b/src/content/notes/8g.md
@@ -8,6 +8,3 @@ updateDate: 2023-09-13
 If a person knows many programming languages, it doesn't mean that they earned the senior title. Someone can be an expert in different programming languages but can still be mid-level. Learning the principles behind a few languages can move you one step further. However, seniority doesn't come with it.
 
 ---
-
-- **Previous Note:** [8f: Seniority is not about being smarter](/notes/8f/);
-- **Next Note:** [8h: Inheriting other people's code](/notes/8h/);

--- a/src/content/notes/8h.md
+++ b/src/content/notes/8h.md
@@ -8,6 +8,3 @@ updateDate: 2023-09-13
 Senior people can quickly analyze the inherited code and understand the things that need to be done. According to the result of the analysis, they can estimate the work and show pitfalls, and requirements.
 
 ---
-
-- **Previous Note:** [8g: It's not about the number of languages you know](/notes/8g/);
-- **Next Note:** [8i: Don't stop asking questions](/notes/8i/);

--- a/src/content/notes/8i.md
+++ b/src/content/notes/8i.md
@@ -9,6 +9,4 @@ The moment you stop asking questions, you stop growing. It doesn't matter if you
 
 ---
 
-- **Previous Note:** [8h: Inheriting other people's code](/notes/8h/);
-- **Next Note:** [8j: Using the Promotion Process to Grow as a Manager](/notes/8j/);
 - **Resourced:** [These (damn) Annoying Tenure Engineers](/these-annoying-tenure-engineers/);

--- a/src/content/notes/8j.md
+++ b/src/content/notes/8j.md
@@ -11,8 +11,6 @@ Managers have to shape their skills according to the team's needs and the constr
 
 ---
 
-- **Previous Note:** [8i: Don't stop asking questions](/notes/8i/);
-- **Next Note:** [9: Growing does not always mean being an expert](/notes/9/);
 - **Related Note(s):**
   - [3: Being a Team Manager and Manager's Job](/notes/3/);
   - [5: Managing Promotions](/notes/5);

--- a/src/content/notes/9.md
+++ b/src/content/notes/9.md
@@ -11,5 +11,3 @@ Growing up in a career doesn't always mean that you become an expert in the fiel
 
 ---
 
-- **Previous Note:** [8j: Using the Promotion Process to Grow as a Manager](/notes/8j/);
-- **Next Note:** [9a: Why you are not a senior](/notes/9a/);

--- a/src/content/notes/9a.md
+++ b/src/content/notes/9a.md
@@ -20,6 +20,4 @@ If you don’t bother to explain your awesome technical solutions to non-technic
 
 ---
 
-- **Previous Note:** [9: Growing does not always mean being an expert](/notes/9/);
-- **Next Note:** [9b: Barriers to Learning from Contact with Reality is ourselves](/notes/9b/);
 - **Related Note(s):** [12a: Making decisions based on three groups](/notes/12a/);

--- a/src/content/notes/9b.md
+++ b/src/content/notes/9b.md
@@ -12,8 +12,6 @@ Three personal barriers to growing as a person are perspective, ego, and account
 
 ---
 
-- **Previous Note:** [9a: Why you are not a senior](/notes/9a/);
-- **Next Note:** [9c: Simple Ideas Prevent Complicated Problems](/notes/9c/);
 - **Related Note(s):**
   - [7: Confident Humility](/notes/7/);
   - [12: Engineer Autonomy](/notes/12/);

--- a/src/content/notes/9c.md
+++ b/src/content/notes/9c.md
@@ -12,8 +12,6 @@ Simple ideas can prevent complicated problems. We often look for complex solutio
 
 ---
 
-- **Previous Note:** [9b: Barriers to Learning from Contact with Reality](/notes/9b/);
-- **Next Note:** [10: Individual Contributor or Manager](/notes/10/);
 - **Related Note(s):**
   - [8: Growing in the Career](/notes/8/);
   - [2c: Write a letter to a friend](/notes/2c/);


### PR DESCRIPTION
The previous and next Zettelkasten note links are already supported on the theme level; no need for extra linking.