### PR TITLE
Fix cursor pointer classes and podcast link

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,7 +8,7 @@ import {site, config} from "../consts";
       <div class="mb-5">
         All content on this website is licensed under
         <a
-        class="truncate cursor-pointr mt-1 hover:text-skin-active"
+        class="truncate cursor-pointer mt-1 hover:text-skin-active"
         href={"https://creativecommons.org/licenses/by-nc-sa/4.0/"}
         target="_blank"
         >

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -91,7 +91,7 @@ let resultPosts = favorites.splice(0, site.recentPostsSize);
           resultPosts.map((post) => (
             <a
               href={"/" + post.slug}
-              class="truncate cursor-pointr mt-1 hover:text-skin-active"
+              class="truncate cursor-pointer mt-1 hover:text-skin-active"
               title={post.data.title}
             >
               {post.data.title}
@@ -107,35 +107,35 @@ let resultPosts = favorites.splice(0, site.recentPostsSize);
       <div class="flex flex-col">
         <a
           href="/now/"
-          class="truncate cursor-pointr mt-1 hover:text-skin-active"
+          class="truncate cursor-pointer mt-1 hover:text-skin-active"
           title="Now"
         >
           Now
         </a>
         <a
           href="/about/"
-          class="truncate cursor-pointr mt-1 hover:text-skin-active"
+          class="truncate cursor-pointer mt-1 hover:text-skin-active"
           title="About"
         >
           About
         </a>
         <a
           href="/podcast/"
-          class="truncate cursor-pointr mt-1 hover:text-skin-active"
+          class="truncate cursor-pointer mt-1 hover:text-skin-active"
           title="Podcast"
         >
           Podcast
         </a>
         <a
           href="/blogroll/"
-          class="truncate cursor-pointr mt-1 hover:text-skin-active"
+          class="truncate cursor-pointer mt-1 hover:text-skin-active"
           title="Blogroll"
         >
           Blogroll
         </a>
         <a
         href="/guestbook/"
-        class="truncate cursor-pointr mt-1 hover:text-skin-active"
+        class="truncate cursor-pointer mt-1 hover:text-skin-active"
         title="Guestbook"
       >
         Guestbook
@@ -143,7 +143,7 @@ let resultPosts = favorites.splice(0, site.recentPostsSize);
       <a
       href="https://linkedin.com/in/candost"
       target="_blank"
-      class="truncate cursor-pointr mt-1 hover:text-skin-active"
+      class="truncate cursor-pointer mt-1 hover:text-skin-active"
       title="Linkedin"
     >
       LinkedIn

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -94,7 +94,7 @@ export const categories = [
       },
       {
         name: "Podcast",
-        href: "/Podcast/",
+        href: "/podcast/",
         target: '_self',
       },
       {

--- a/src/pages/books/index.astro
+++ b/src/pages/books/index.astro
@@ -13,7 +13,7 @@ let sortedPosts = sortPostsByDate(posts);
   <h1 class="text-3xl fa-2x mb-5 mt-10">Book Notes</h1>
   <p class="mb-5">I share either a full book review or a single-chapter note from the books I read.</p>
 
-  <p class="mb-10">You can get new book notes in your favorite RSS reader via <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="/books/rss.xml">the dedicated RSS feed</a>.</p>
+  <p class="mb-10">You can get new book notes in your favorite RSS reader via <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="/books/rss.xml">the dedicated RSS feed</a>.</p>
 
   <div class="divider-horizontal"/>
   <div>

--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -14,7 +14,7 @@ let sortedPosts = sortPostsByDate(posts);
   <h1 class="text-3xl mb-5 mt-10">Zeitschrift auf Deutsch</h1>
   <p class="mb-5">Ich lerne Deutch und möchte üben. Deshalb habe ich mich entschlossen, in meinem Blog eine Abteilung zum Thema Deutch einzurichten.</p>
 
-  <p class="mb-10">Du kannst neue Artikeln mit RSS-reader lesen. <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="/de/rss.xml">Hier ist die RSS feed.</a>.</p>
+  <p class="mb-10">Du kannst neue Artikeln mit RSS-reader lesen. <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="/de/rss.xml">Hier ist die RSS feed.</a>.</p>
   <div class="divider-horizontal"/>
   <div>
     <ul>

--- a/src/pages/journal/index.astro
+++ b/src/pages/journal/index.astro
@@ -15,7 +15,7 @@ posts = sortPostsByDate(posts);
 
   <p class="mb-5">One thing I miss about social media is posting short ideas or sharing links with others. So, I decided to bring them here. These are not full-fledged posts. Instead, it can be a draft idea, a link to a post, a short comment about something, a life update, etc.</p>
 
-  <p class="mb-10">You can get new entries in your favorite RSS reader via <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="/journal/rss.xml">the dedicated RSS feed</a>.</p>
+  <p class="mb-10">You can get new entries in your favorite RSS reader via <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="/journal/rss.xml">the dedicated RSS feed</a>.</p>
   <div class="divider-horizontal"/>
 
   {posts.map((post, index) => <FeedPreview post={post} index={index} />)}

--- a/src/pages/newsletter/index.astro
+++ b/src/pages/newsletter/index.astro
@@ -36,7 +36,7 @@ let sortedMediations = await sortPostsByIssueNumberDec(mediations);
     </ul>
   </div>
   <div>
-    <p class="italic text-sm">You can also get new letters to your favorite RSS reader via <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="/newsletter/rss.xml">the dedicated RSS feed</a>.</p>
+    <p class="italic text-sm">You can also get new letters to your favorite RSS reader via <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="/newsletter/rss.xml">the dedicated RSS feed</a>.</p>
     <div class="divider-horizontal"/>
     <p class="mb-10 mt-10 text-sm">I used to write another newsletter called Mektup. If you want to find the archives,  <a class="underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500" href="/mektup/">click here.</a></p>
   </div>

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -18,7 +18,7 @@ let sortedPosts = sortNotesByZettelId(zettels);
   <p class="mt-3">If you dive into notes, you'll see all notes are connected to each other but not all notes have sources linked to it. Many notes have references in my non-public Zettelkasten; I didn't want to open up those exact references because there is no value for anyone as they are not well-organized or well-written. Here, I only share the name of the resource instead of the exact reference (e.g., page number in a book).</p>
   <p class="mt-3">All notes have published and update dates. Published dates represent the time I added the note to my Zettelkasten. Yet, many notes has the exact same creation date because I moved my notes between different softwares (from Notion to Obsidian) and lost the creation dates during migration. 🤷</p>
 
-  <p class="mb-10 mt-10">If you want, you can get new notes in your favorite RSS reader via <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="/notes/rss.xml">the dedicated RSS feed</a>.</p>
+  <p class="mb-10 mt-10">If you want, you can get new notes in your favorite RSS reader via <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="/notes/rss.xml">the dedicated RSS feed</a>.</p>
 
   <div class="divider-horizontal"/>
 

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -17,7 +17,7 @@ let sortedPosts = sortPostsByDate(posts);
   <p class="mt-3">If you dive into notes, you'll see all notes are connected to each other but not all notes have sources linked to it. Many notes have references in my non-public Zettelkasten; I didn't want to open up those exact references because there is no value for anyone as they are not well-organized or well-written. Here, I only share the name of the resource instead of the exact reference (e.g., page number in a book).</p>
   <p class="mt-3">All notes have published and update dates. Published dates represent the time I added the note to my Zettelkasten. Yet, many notes has the exact same creation date because I moved my notes between different softwares (from Notion to Obsidian) and lost the creation dates during migration. 🤷</p>
 
-  <p class="mb-10 mt-10">You can get new notes in your favorite RSS reader via <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="/notes/rss.xml">the dedicated RSS feed</a>.</p>
+  <p class="mb-10 mt-10">You can get new notes in your favorite RSS reader via <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="/notes/rss.xml">the dedicated RSS feed</a>.</p>
 
   <div class="divider-horizontal"/>
   <p class="fa-m mb-10 mt-10"><em>The notes are ordered squentially by their Zettel numbers, not chronologically.</em></p>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -14,7 +14,7 @@ let resultPosts = getPostsByYear(sortedPosts);
 
 <IndexPage frontmatter={{ comment: false, title: "Posts" }}>
   <h1 class="text-3xl fa-2x mb-5 mt-10">Posts</h1>
-  You can get new posts in your favorite RSS reader via <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="/posts/rss.xml">the dedicated RSS feed.</a>
+  You can get new posts in your favorite RSS reader via <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="/posts/rss.xml">the dedicated RSS feed.</a>
   {
     Object.keys(resultPosts)
       .sort((a, b) => Number(b) - Number(a))

--- a/src/pages/talk/index.astro
+++ b/src/pages/talk/index.astro
@@ -13,13 +13,13 @@ import NewsletterForm from "../../components/NewsletterForm.astro";
 
   <NewsletterForm/>
 
-  <p class="mt-5">If you use RSS reader, you can add <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="/feeds">my RSS feed</a> to your RSS reader app.</p>
+  <p class="mt-5">If you use RSS reader, you can add <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="/feeds">my RSS feed</a> to your RSS reader app.</p>
   <div>
 
-  <p class="mt-5">If you like, you can also follow me <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="https://www.linkedin.com/comm/mynetwork/discovery-see-all?usecase=PEOPLE_FOLLOWS&followMember=candost">on LinkedIn</a>. Don't forget to add a note in connection request and mention the place you listened to me so I can comfortably accept your invitation.</p>
+  <p class="mt-5">If you like, you can also follow me <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="https://www.linkedin.com/comm/mynetwork/discovery-see-all?usecase=PEOPLE_FOLLOWS&followMember=candost">on LinkedIn</a>. Don't forget to add a note in connection request and mention the place you listened to me so I can comfortably accept your invitation.</p>
 
   <h2 class="text-xl mt-10">How can you contact me?</h2>
-  <p class="mt-5">You can send me an email via <a class="truncate cursor-pointr mt-1 header-link-active hover:text-skin-active" href="mailto:contact@candostdagdeviren.com">contact[at]candostdagdeviren[dot]com</a>. If you share your feedback about my talk, it will make my day.</p>
+  <p class="mt-5">You can send me an email via <a class="truncate cursor-pointer mt-1 header-link-active hover:text-skin-active" href="mailto:contact@candostdagdeviren.com">contact[at]candostdagdeviren[dot]com</a>. If you share your feedback about my talk, it will make my day.</p>
 
   <p class="mt-5">No sales pitches, no marketing emails, please. I won't answer them.</p>
   </div>


### PR DESCRIPTION
## Summary
- fix pointer cursor typos across templates
- fix Podcast link path in navigation

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845802d6b38832eb6215ff0ab9ec63f