### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a **static Astro blog** (candost.blog): SSG only (`output: 'static'`),
+no backend, database, or auth. It builds to `dist/` and deploys to Netlify.
+
+### Services / commands
+
+Standard scripts live in `package.json`. There is a single "service" (the Astro dev server):
+
+- `pnpm dev` — dev server at `http://localhost:4321` (port set in `astro.config.mjs`). Hot-reloads on content/source changes.
+- `pnpm build` — production build to `dist/` (also emits `sitemap-*.xml` and `robots.txt`).
+- `pnpm preview` — serve the built `dist/` output.
+- `pnpm astro check` — Astro/TypeScript content + type check (see caveat below).
+
+### Non-obvious caveats
+
+- **pnpm only.** A `preinstall` hook (`only-allow pnpm`) and `engines.pnpm >=10` reject npm/yarn; `package-lock.json`/`yarn.lock` are gitignored to enforce this. Use `pnpm`.
+- **`pnpm astro check` currently reports ~73 pre-existing TypeScript errors** (mostly implicit `any` in `src/utils`, `src/components`). These exist on `main`, are unrelated to build, and `astro check` is not wired as a package.json script. Do not treat them as regressions — only worry about new errors you introduce.
+- **Ignored build-scripts warning is harmless.** `pnpm install` prints "Ignored build scripts: sharp, esbuild, @parcel/watcher". These ship prebuilt binaries, so `pnpm build`/`pnpm dev` work without approving them. Do NOT run the interactive `pnpm approve-builds`.
+- **Content** lives in `src/content/*` collections (schemas in `src/content.config.ts`). Adding a markdown file (e.g. under `src/content/posts/`) is picked up live by the dev server; a build produces one static page per entry.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for this static Astro blog. No application code changed — only adds `AGENTS.md` capturing durable, non-obvious dev instructions for future Cursor Cloud agents.

## What was verified

- `pnpm install` — dependencies install cleanly (pnpm 10.33, Node 22).
- `pnpm build` — production build succeeds, 979 pages built + sitemap/robots.txt.
- `pnpm dev` — dev server runs at `http://localhost:4321`, serves HTTP 200.
- `pnpm astro check` — runs, but reports ~73 pre-existing TypeScript errors on `main` (documented in AGENTS.md; unrelated to build).

## Hello-world

Created a temporary post, confirmed it rendered live via dev server hot reload (homepage, post page, and posts listing), then removed it (not committed).

[astro_blog_dev_server_demo.mp4](https://cursor.com/agents/bc-b791a4b2-b9e2-45b6-a4c4-33e1242392db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_blog_dev_server_demo.mp4)

[Rendered hello-world post](https://cursor.com/agents/bc-b791a4b2-b9e2-45b6-a4c4-33e1242392db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_post_rendered.webp)

## Update script

`pnpm install`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b791a4b2-b9e2-45b6-a4c4-33e1242392db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b791a4b2-b9e2-45b6-a4c4-33e1242392db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

