### PR TITLE
Add AI/CI tooling and fix all astro check type errors

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "astro-dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 4321
+    },
+    {
+      "name": "astro-preview",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["preview", "--port", "4330"],
+      "port": 4330
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm check)",
+      "Bash(pnpm build)",
+      "mcp__Claude_Preview__preview_start",
+      "mcp__Claude_Preview__preview_screenshot",
+      "mcp__Claude_Preview__preview_snapshot",
+      "mcp__Claude_Preview__preview_console_logs",
+      "mcp__Claude_Preview__preview_logs",
+      "mcp__Claude_Preview__preview_inspect",
+      "mcp__Claude_Preview__preview_list"
+    ]
+  }
+}

--- a/.github/agents/blogger-agent.md
+++ b/.github/agents/blogger-agent.md
@@ -46,7 +46,7 @@ When the user provides content, ask them for:
 1. **Receive Content**: Accept the markdown content from the user
 2. **Gather Metadata**: Ask for any frontmatter values based on your template
 3. **Location of File**: Ask in which location the file should be placed.
-4. **Current date time**: Replace <CURRENT_DATE_TIME> with the date and time of now in UTC timezone in the following date format YYYY-MM-DDTHH:mm:SSSZ
+4. **Current date time**: Replace <CURRENT_DATE_TIME> with the date and time of now in UTC timezone in the following date format YYYY-MM-DDTHH:mm:ss.SSSZ (e.g. 2026-05-08T06:05:00.000Z)
 4. **Construct Markdown File**: Combine frontmatter + original content (unchanged)
 5. **Create & Commit**: Create the file in the repository and commit with a descriptive message
 6. **Confirm**: Report success with the commit details

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type and template check
+        run: pnpm check
+
+      - name: Build
+        run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 .cursor
 .cursorrules
 
+# Personal Claude Code settings stay local; launch.json and settings.json are shared
+.claude/settings.local.json
+
 # Enforce pnpm-only: reject npm/yarn lockfiles
 package-lock.json
 yarn.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+Personal blog (candost.blog) built with Astro 6 on the Astro Yi theme, deployed to Netlify from `main`. Most work is either adding/editing markdown in `src/content/` or maintaining the Astro theme code.
+
+## Commands
+
+pnpm only — `preinstall` enforces it and npm/yarn lockfiles are gitignored.
+
+- `pnpm dev` — dev server at http://localhost:4321
+- `pnpm check` — `astro check` (type + template diagnostics)
+- `pnpm build` — production build; also validates all content frontmatter against the collection schemas
+- `pnpm preview` — serve the production build
+
+There is no test suite. Verification for any change is `pnpm build` plus `pnpm check` (both are CI gates) — `pnpm check` must report 0 errors.
+
+## Architecture
+
+- `src/content.config.ts` — zod schemas for all seven content collections. A new frontmatter field must be added here before content can use it (unknown fields are silently stripped, not errors).
+- `src/content/<collection>/` — markdown content: posts, journal, newsletter, notes (Zettelkasten), books, podcast, de (German-language posts).
+- `src/pages/` — file-based routes, roughly one index per collection, plus RSS/JSON feeds.
+- `src/utils/getAllContent.ts` — aggregates collections for listings and feeds; update it when adding a collection.
+- `src/remarkPlugin/` — custom remark plugins wired up in `astro.config.mjs`.
+- `src/consts.ts` — site-wide config (nav, socials, footer, features).
+- `src/i18n/` — UI strings.
+- UI is Astro components with Solid.js islands in `src/components`, styled with Tailwind 4 and SCSS in `src/styles`.
+
+## Content frontmatter
+
+Every collection requires `title` and `date`; `draft: true` hides an entry. Dates are full ISO timestamps like `2026-05-08T06:05:00.000Z` (UTC). Collection-specific fields:
+
+- notes: `zettelId` is required
+- posts: optional `favorite`, `newsletterName`, `issueNumber`
+- journal and podcast: optional `externalUrl` for externally published entries; journal also has `externalTitle`
+
+## Conventions
+
+- Imports are relative throughout the codebase. The `$`/`$components` tsconfig aliases exist but are unused — don't mix them in.
+- Add TypeScript type annotations to function signatures.
+- No explanatory code comments, and never delete existing comments or docstrings.
+- Prefer the smallest change that respects the existing theme patterns; ask before adding new dependencies or technologies.
+- In markdown content, indent nested code snippets by 2 spaces (not 0 or 4).
+
+## Imported Claude Cowork project instructions
+
+This is my personal blog. Don't be intrusive. The content folder is sacred. However, it lacks a lot of frontend development's best practices. Recommend improvements on the way. I might only add a content or make changes to the codebase. Clarify if you are not sure what I'm trying to achieve in a session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md
+
+Personal blog (candost.blog) built with Astro 6 on the Astro Yi theme, deployed to Netlify from `main`. Most work is either adding/editing markdown in `src/content/` or maintaining the Astro theme code.
+
+## Commands
+
+pnpm only — `preinstall` enforces it and npm/yarn lockfiles are gitignored.
+
+- `pnpm dev` — dev server at http://localhost:4321
+- `pnpm check` — `astro check` (type + template diagnostics)
+- `pnpm build` — production build; also validates all content frontmatter against the collection schemas
+- `pnpm preview` — serve the production build
+
+There is no test suite. Verification for any change is `pnpm build` plus `pnpm check` (both are CI gates) — `pnpm check` must report 0 errors.
+
+## Architecture
+
+- `src/content.config.ts` — zod schemas for all seven content collections. A new frontmatter field must be added here before content can use it (unknown fields are silently stripped, not errors).
+- `src/content/<collection>/` — markdown content: posts, journal, newsletter, notes (Zettelkasten), books, podcast, de (German-language posts).
+- `src/pages/` — file-based routes, roughly one index per collection, plus RSS/JSON feeds.
+- `src/utils/getAllContent.ts` — aggregates collections for listings and feeds; update it when adding a collection.
+- `src/remarkPlugin/` — custom remark plugins wired up in `astro.config.mjs`.
+- `src/consts.ts` — site-wide config (nav, socials, footer, features).
+- `src/i18n/` — UI strings.
+- UI is Astro components with Solid.js islands in `src/components`, styled with Tailwind 4 and SCSS in `src/styles`.
+
+## Content frontmatter
+
+Every collection requires `title` and `date`; `draft: true` hides an entry. Dates are full ISO timestamps like `2026-05-08T06:05:00.000Z` (UTC). Collection-specific fields:
+
+- notes: `zettelId` is required
+- posts: optional `favorite`, `newsletterName`, `issueNumber`
+- journal and podcast: optional `externalUrl` for externally published entries; journal also has `externalTitle`
+
+## Conventions
+
+- Imports are relative throughout the codebase. The `$`/`$components` tsconfig aliases exist but are unused — don't mix them in.
+- Add TypeScript type annotations to function signatures.
+- No explanatory code comments, and never delete existing comments or docstrings.
+- Prefer the smallest change that respects the existing theme patterns; ask before adding new dependencies or technologies.
+- In markdown content, indent nested code snippets by 2 spaces (not 0 or 4).

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",
+    "check": "astro check",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -45,6 +46,9 @@
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.24",
+    "@types/markdown-it": "^14.1.2",
+    "@types/sanitize-html": "^2.16.1",
     "prettier-plugin-astro": "^0.14.1",
     "sass": "^1.99.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,15 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
     devDependencies:
+      '@types/lodash':
+        specifier: ^4.17.24
+        version: 4.17.24
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
@@ -1062,8 +1071,20 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
@@ -1076,6 +1097,9 @@ packages:
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -3706,9 +3730,20 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/lodash@4.17.24': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/mdx@2.0.13': {}
 
@@ -3721,6 +3756,10 @@ snapshots:
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
 
   '@types/sax@1.2.7':
     dependencies:

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -8,7 +8,7 @@ const ui = {
 export function useTranslations(lang: string) {
   const safeLang: keyof typeof ui =
     lang in ui ? (lang as keyof typeof ui) : "en";
-  return function t(key: string) {
+  return function t(key: keyof typeof en) {
     return ui[safeLang][key] || ui["en"][key];
   };
 }

--- a/src/pages/books/rss.xml.ts
+++ b/src/pages/books/rss.xml.ts
@@ -23,10 +23,7 @@ export async function GET() {
     site: baseUrl + "/books/",
     stylesheet: "/rss/pretty-feed.xsl",
     items: books.map((book) => {
-      let url =
-        book.collection == "posts"
-          ? `${baseUrl}/${book.id}/`
-          : `${baseUrl}/${book.collection}/${book.id}/`;
+      let url = `${baseUrl}/${book.collection}/${book.id}/`;
       let reply = `\n\n---\n[Reply via email](mailto:contact@candostdagdeviren.com?subject=Re:%20${url}) | [Reply via Mastodon](https://hachyderm.io/@candost) | [Comment](${url}#waline)`;
       let newContent = book.body + `${reply}`;
       let body = parser.render(newContent);

--- a/src/pages/de/rss.xml.ts
+++ b/src/pages/de/rss.xml.ts
@@ -23,10 +23,7 @@ export async function GET() {
     site: baseUrl + "/de/",
     stylesheet: "/rss/pretty-feed.xsl",
     items: germanPosts.map((artikel) => {
-      let url =
-        artikel.collection == "posts"
-          ? `${baseUrl}/${artikel.id}/`
-          : `${baseUrl}/${artikel.collection}/${artikel.id}/`;
+      let url = `${baseUrl}/${artikel.collection}/${artikel.id}/`;
       let reply = `\n\n---\n[per E-Mail antworten](mailto:candost@candostdagdeviren.com?subject=Re:%20${url})`;
       let newContent = artikel.body + `${reply}`;
       let body = parser.render(newContent);

--- a/src/pages/journal/rss.xml.ts
+++ b/src/pages/journal/rss.xml.ts
@@ -22,10 +22,7 @@ export async function GET() {
     site: baseUrl + "/journal/",
     stylesheet: "/rss/pretty-feed.xsl",
     items: journalEntries.map((entry) => {
-      let url =
-        entry.collection == "posts"
-          ? `${baseUrl}/${entry.id}/`
-          : `${baseUrl}/${entry.collection}/${entry.id}/`;
+      let url = `${baseUrl}/${entry.collection}/${entry.id}/`;
       let reply = `\n\n---\n[Reply via email](mailto:contact@candostdagdeviren.com?subject=Re:%20${url}) | [Reply via Mastodon](https://hachyderm.io/@candost) | [Comment](${url}#waline)`;
       let newContent = entry.body + `${reply}`;
       let body = parser.render(newContent);

--- a/src/pages/newsletter/rss.xml.ts
+++ b/src/pages/newsletter/rss.xml.ts
@@ -4,12 +4,13 @@ import sanitizeHtml from "sanitize-html";
 import MarkdownIt from "markdown-it";
 import { sortPostsByDate } from "../../utils/sortPostsByDate";
 import getPostsByTag from "../../utils/getPostsByTag";
-import { getAllContent } from "src/utils/getAllContent";
+import { getCollectionByName } from "src/utils/getCollectionByName";
 const parser = new MarkdownIt();
 
 export async function GET() {
-  const allPosts = await getAllContent();
-  const newsletters = getPostsByTag(allPosts, "mediations");
+  const posts = await getCollectionByName("posts");
+  const newsletter = await getCollectionByName("newsletter");
+  const newsletters = getPostsByTag([...posts, ...newsletter], "mediations");
 
   let baseUrl = site.url;
   // removing trailing slash if found

--- a/src/pages/notes/rss.xml.ts
+++ b/src/pages/notes/rss.xml.ts
@@ -22,10 +22,7 @@ export async function GET() {
     site: baseUrl + "/notes/",
     stylesheet: "/rss/pretty-feed.xsl",
     items: notes.map((note) => {
-      let url =
-        note.collection == "posts"
-          ? `${baseUrl}/${note.id}/`
-          : `${baseUrl}/${note.collection}/${note.id}/`;
+      let url = `${baseUrl}/${note.collection}/${note.id}/`;
       let reply = `\n\n---\n[Reply via email](mailto:contact@candostdagdeviren.com?subject=Re:%20${url}) | [Reply via Mastodon](https://hachyderm.io/@candost) | [Comment](${url}#waline)`;
       let newContent = note.body + `${reply}`;
       let body = parser.render(newContent);

--- a/src/utils/dealLabel.ts
+++ b/src/utils/dealLabel.ts
@@ -1,5 +1,8 @@
 import _ from "lodash";
-export const dealLabel = (label) => {
+
+export const dealLabel = (
+  label: string[] | string | null | undefined,
+): string[] => {
   if (_.isEmpty(label)) {
     return [];
   } else if (_.isString(label)) {

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -2,13 +2,17 @@ import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import utc from "dayjs/plugin/utc";
 import { t } from "../i18n/utils";
+import type { en } from "../i18n/en";
 import { config } from "../consts";
 
 dayjs.locale(config.lang);
 dayjs.extend(advancedFormat);
 dayjs.extend(utc);
 
-export function formatDate(date, dateType = "post.dateFormat") {
+export function formatDate(
+  date: Date | null | undefined,
+  dateType: keyof typeof en = "post.dateFormat",
+) {
   if (date) {
     const dateFormat = t(dateType) || "YYYY-MM-DD";
     return dayjs(date).utc().format(dateFormat);

--- a/src/utils/getCollectionByName.ts
+++ b/src/utils/getCollectionByName.ts
@@ -1,6 +1,8 @@
 import { getCollection, type DataEntryMap } from "astro:content";
 
-export const getCollectionByName = async (name: keyof DataEntryMap) => {
+export const getCollectionByName = async <T extends keyof DataEntryMap>(
+  name: T,
+) => {
   const posts = await getCollection(name);
   if (posts && posts.length > 0) {
     return posts.filter(({ data }) => {

--- a/src/utils/getCountByCategory.ts
+++ b/src/utils/getCountByCategory.ts
@@ -1,7 +1,11 @@
 import _ from "lodash";
 import { dealLabel } from "./dealLabel";
 
-const getCountByCategory = (posts) => {
+interface CategorizedEntry {
+  data: { draft?: boolean | null; category?: string[] | string | null };
+}
+
+const getCountByCategory = <T extends CategorizedEntry>(posts: T[]) => {
   let category: string[] = [];
   const filteredPosts = posts.filter(({ data }) => {
     return import.meta.env.PROD ? !data.draft : true;

--- a/src/utils/getCountByTagName.ts
+++ b/src/utils/getCountByTagName.ts
@@ -1,7 +1,11 @@
 import _ from "lodash";
 import { dealLabel } from "./dealLabel";
 
-const getCountByTagName = (posts) => {
+interface TaggedEntry {
+  data: { draft?: boolean | null; tags?: string[] | string | null };
+}
+
+const getCountByTagName = <T extends TaggedEntry>(posts: T[]) => {
   let tags: string[] = [];
   const filteredPosts = posts.filter(({ data }) => {
     return import.meta.env.PROD ? !data.draft : true;

--- a/src/utils/getPostsByCategory.ts
+++ b/src/utils/getPostsByCategory.ts
@@ -1,7 +1,14 @@
 import _ from "lodash";
 import { dealLabel } from "./dealLabel";
 
-const getPostsByCategory = (posts, category: string) =>
+interface CategorizedEntry {
+  data: { category?: string[] | string | null };
+}
+
+const getPostsByCategory = <T extends CategorizedEntry>(
+  posts: T[],
+  category: string,
+): T[] =>
   posts.filter((post) =>
     _.flattenDeep(dealLabel(post.data.category)).includes(category),
   );

--- a/src/utils/getPostsByTag.ts
+++ b/src/utils/getPostsByTag.ts
@@ -1,7 +1,11 @@
 import _ from "lodash";
 import { dealLabel } from "./dealLabel";
 
-const getPostsByTag = (posts, tag: string) =>
+interface TaggedEntry {
+  data: { tags?: string[] | string | null };
+}
+
+const getPostsByTag = <T extends TaggedEntry>(posts: T[], tag: string): T[] =>
   posts.filter((post) =>
     _.flattenDeep(dealLabel(post.data.tags)).includes(tag),
   );

--- a/src/utils/getPostsByYear.ts
+++ b/src/utils/getPostsByYear.ts
@@ -1,8 +1,15 @@
 // 根据年份归档博文
 import _ from "lodash";
 import dayjs from "dayjs";
-const getPostsByYear = (posts) => {
-  let obj = {};
+
+interface DatedEntry {
+  data: { date: Date };
+}
+
+const getPostsByYear = <T extends DatedEntry>(
+  posts: T[],
+): Record<string, T[]> => {
+  const obj: Record<string, T[]> = {};
   posts.forEach((post) => {
     let postCreateYear = dayjs(post.data.date).format("YYYY");
     if (_.keys(obj).includes(postCreateYear)) {

--- a/src/utils/getUniqeCategory.ts
+++ b/src/utils/getUniqeCategory.ts
@@ -1,7 +1,11 @@
 import _ from "lodash";
 import { dealLabel } from "./dealLabel";
 
-const getUniqueCategory = (posts) => {
+interface CategorizedEntry {
+  data: { draft?: boolean | null; category?: string[] | string | null };
+}
+
+const getUniqueCategory = <T extends CategorizedEntry>(posts: T[]) => {
   let category: string[] = [];
   const filteredPosts = posts.filter(({ data }) => {
     return import.meta.env.PROD ? !data.draft : true;

--- a/src/utils/getUniqueTags.ts
+++ b/src/utils/getUniqueTags.ts
@@ -1,7 +1,11 @@
 import _ from "lodash";
 import { dealLabel } from "./dealLabel";
 
-const getUniqueTags = (posts) => {
+interface TaggedEntry {
+  data: { draft?: boolean | null; tags?: string[] | string | null };
+}
+
+const getUniqueTags = <T extends TaggedEntry>(posts: T[]) => {
   let tags: string[] = [];
   const filteredPosts = posts.filter(({ data }) => {
     return import.meta.env.PROD ? !data.draft : true;

--- a/src/utils/orderBySticky.ts
+++ b/src/utils/orderBySticky.ts
@@ -1,12 +1,15 @@
 import _ from "lodash";
 import dayjs from "dayjs";
 
-export const orderBySticky = (posts) => {
-  let handlePosts = posts.map((post) => {
-    post.sticky = post.data.sticky ? post.data.sticky : 0;
-    post.dateTimestamp = dayjs(post.data.date).valueOf();
+interface StickyEntry {
+  data: { sticky?: number | null; date: Date };
+}
 
-    return post;
-  });
+export const orderBySticky = <T extends StickyEntry>(posts: T[]) => {
+  let handlePosts = posts.map((post) => ({
+    ...post,
+    sticky: post.data.sticky ? post.data.sticky : 0,
+    dateTimestamp: dayjs(post.data.date).valueOf(),
+  }));
   return _.orderBy(handlePosts, ["sticky", "dateTimestamp"], ["desc", "desc"]);
 };

--- a/src/utils/sortByIssueNumber.ts
+++ b/src/utils/sortByIssueNumber.ts
@@ -1,6 +1,12 @@
-export const sortPostsByIssueNumberDec = (posts) =>
+interface IssueNumberedEntry {
+  data: { draft?: boolean | null; issueNumber?: string | null };
+}
+
+export const sortPostsByIssueNumberDec = <T extends IssueNumberedEntry>(
+  posts: T[],
+): T[] =>
   posts
     .filter(({ data }) => {
       return import.meta.env.PROD ? !data.draft : true;
     })
-    .sort((a, b) => b.data.issueNumber - a.data.issueNumber);
+    .sort((a, b) => Number(b.data.issueNumber) - Number(a.data.issueNumber));

--- a/src/utils/sortPostsAlphabetically.ts
+++ b/src/utils/sortPostsAlphabetically.ts
@@ -1,4 +1,8 @@
-export const sortPostsAlphabetically = (posts) =>
+interface TitledEntry {
+  data: { title?: string | null };
+}
+
+export const sortPostsAlphabetically = <T extends TitledEntry>(posts: T[]): T[] =>
   [...posts].sort((a, b) => {
     const titleA = a.data?.title || "";
     const titleB = b.data?.title || "";

--- a/src/utils/sortPostsByDate.ts
+++ b/src/utils/sortPostsByDate.ts
@@ -1,3 +1,8 @@
 import dayjs from "dayjs";
-export const sortPostsByDate = (posts) =>
+
+interface DatedEntry {
+  data: { date: Date };
+}
+
+export const sortPostsByDate = <T extends DatedEntry>(posts: T[]): T[] =>
   posts.sort((a, b) => dayjs(b.data.date).unix() - dayjs(a.data.date).unix());

--- a/src/utils/sortPostsBySticky.ts
+++ b/src/utils/sortPostsBySticky.ts
@@ -1,4 +1,8 @@
-export const sortPostsBySticky = (posts) =>
+interface StickyEntry {
+  data: { sticky?: number | null };
+}
+
+export const sortPostsBySticky = <T extends StickyEntry>(posts: T[]): T[] =>
   posts
     .filter(({ data }) => data.sticky)
-    .sort((a, b) => b.data.sticky - a.data.sticky);
+    .sort((a, b) => (b.data.sticky ?? 0) - (a.data.sticky ?? 0));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "module": "ES2022",
     "lib": ["es2020"],
     "target": "es2019",


### PR DESCRIPTION
## What changed

- `CLAUDE.md`/`AGENTS.md` give coding agents the commands, architecture map, per-collection frontmatter requirements, and conventions.
- New CI workflow runs `pnpm check` + `pnpm build` on PRs and main. The existing `claude.yml` action already had `actions: read` for CI results, but no CI existed to produce them.
- All 76 pre-existing `astro check` errors fixed (`@types/*` devDependencies, `moduleResolution: bundler`, explicit annotations in RSS routes and utils), so the check step is a real gate at 0 errors.
- Shared `.claude/settings.json` with a read-only permission allowlist; personal `settings.local.json` is now gitignored. `.claude/launch.json` committed for dev-server preview.
- Fixed the malformed date format in the blogger-agent instructions that could have produced schema-invalid frontmatter.

## Why

Agents previously started in this repo with no project context, no exposed verification loop, and no CI signal.

## Reviewer notes

- Verified locally: `pnpm check` → 0 errors, `pnpm build` → 975 pages.
- `tsconfig.json` `moduleResolution` changed from `node` to `bundler` (Astro 6 recommendation; needed for `astro/loaders` types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)