### PR TITLE
Fix astro check regression from @astrojs/rss 4.0.19 (post-#73 follow-up)

### DIFF
--- a/src/utils/sortNotesByZettelId.ts
+++ b/src/utils/sortNotesByZettelId.ts
@@ -2,6 +2,9 @@ import type { CollectionEntry } from "astro:content";
 import { filterDrafts } from "./filterDrafts";
 
 export const sortNotesByZettelId = (posts: CollectionEntry<"notes">[]) =>
+  // `zettelId` typechecks as `unknown` here under moduleResolution "bundler"
+  // (likely a zod v4 dual-resolution quirk in Astro's generated content
+  // types, see PR #76) even though it's a plain string at runtime.
   filterDrafts(posts).sort((a, b) => {
     return a.data.zettelId.localeCompare(b.data.zettelId, "en-US", {
       numeric: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "module": "ES2022",
     "lib": ["es2020"],
     "target": "es2019",


### PR DESCRIPTION
## Summary

A review comment on #73 (the Astro 7 dependency consolidation, now merged) asked to confirm `astro check` passes cleanly, since that PR deliberately held `typescript` at `^6`. It doesn't — running `pnpm run check` on current `main` turns up **7 new errors** that weren't there before #73:

```
src/pages/books/rss.xml.ts:1:17 - error ts(2307): Cannot find module '@astrojs/rss' or its corresponding type declarations.
src/pages/de/rss.xml.ts:1:17 - error ts(2307): Cannot find module '@astrojs/rss' ...
src/pages/journal/rss.xml.ts:1:17 - error ts(2307): Cannot find module '@astrojs/rss' ...
src/pages/newsletter/rss.xml.ts:1:17 - error ts(2307): Cannot find module '@astrojs/rss' ...
src/pages/notes/rss.xml.ts:1:17 - error ts(2307): Cannot find module '@astrojs/rss' ...
src/pages/posts/rss.xml.ts:1:17 - error ts(2307): Cannot find module '@astrojs/rss' ...
src/pages/rss.xml.ts:1:17 - error ts(2307): Cannot find module '@astrojs/rss' ...
src/utils/buildFeedItems.ts:3:34 - error ts(2307): Cannot find module '@astrojs/rss' ...
```

I confirmed this by comparing `astro check` output on `main` before #73 (28 pre-existing, unrelated errors — implicit `any` params, missing `@types/lodash`, etc.) against `main` after #73 (36 errors: the same 28 plus these 7 new ones).

## Root cause

`@astrojs/rss` **4.0.19** dropped the top-level `"types"` field from its `package.json` (present in 4.0.18), while its `exports` map still doesn't declare a `types` condition — it's a bare string (`"." : "./dist/index.js"`). This project's `tsconfig.json` used `moduleResolution: "node"` (classic resolution), which ignores `exports` for type resolution entirely and only reads the top-level `types`/`main` fields. Without a top-level `types` field, TypeScript can no longer find `@astrojs/rss`'s shipped `dist/index.d.ts` — even though the file is still there and unchanged.

`pnpm build` was and is unaffected, since Vite/Rolldown resolve the JS itself via `exports` at build/runtime, and don't need the `.d.ts` at all. This is purely a typecheck-time regression.

## Fix

Switch `moduleResolution` from `"node"` to `"bundler"` in `tsconfig.json`. This is the mode generally recommended for Vite/Astro projects, and it actually matches how this project's own bundler resolves modules — so it falls back to the sibling `.d.ts` file next to the `exports` target, the same way Vite resolves the JS. All 7 new errors clear.

```diff
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
```

## Verification

- `pnpm build` → **978 pages, no errors** (unchanged)
- `pnpm run check` → **28 errors**, down from 36 — exactly the same count as `main`'s pre-existing baseline *before* #73. (One of the 28 is a different error than before: switching resolution mode also changed how one already-fragile generic-inference case in `sortNotesByZettelId.ts` resolves a zod-derived field type, likely a zod v4 dual-package-hazard quirk surfaced by the resolution mode change rather than anything in this repo's code. It's typecheck-only — the field is genuinely a string at runtime — and not something a one-line fix in that file could clear, since even an explicit type annotation on the callback didn't help. Given `astro check` isn't CI-gated here and this doesn't affect the build, I've left it rather than chase a deeper zod-typing rabbit hole; happy to dig further if you'd like.)

## Not in scope

- The 28 pre-existing `astro check` errors (implicit `any` params across several `src/utils/*.ts` files, missing `@types/lodash`) predate this change and are unrelated to the Astro 7 upgrade.
- No CI workflow runs `pnpm build` or `pnpm run check` on this repo yet — noted as a follow-up in #73's description, still applicable here.

---
_Generated by [Claude Code](https://claude.ai/code/session_019kLLiH5cnKmWhUvjBsPdHg)_