### PR TITLE
Add IndieWeb microformats2 markup (h-card, h-entry, h-feed, rel-me)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  microformats:
+    name: Build and verify microformats
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The tests read dist/, so the site has to be built first.
+      - name: Build site
+        run: pnpm build
+
+      - name: Verify microformats markup
+        run: pnpm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# This workflow only reads the repository to build and test it.
+permissions:
+  contents: read
+
 jobs:
   microformats:
     name: Build and verify microformats

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 # This workflow only reads the repository to build and test it.
 permissions:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
+    "test": "node --test \"tests/**/*.test.mjs\"",
+    "test:build": "astro build && node --test \"tests/**/*.test.mjs\"",
     "astro": "astro"
   },
   "dependencies": {
@@ -45,6 +47,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
+    "microformats-parser": "^2.0.6",
     "prettier-plugin-astro": "^0.14.1",
     "sass": "^1.101.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.10
         version: 0.9.10(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@7.0.2)
+      microformats-parser:
+        specifier: ^2.0.6
+        version: 2.0.6
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
@@ -2202,6 +2205,10 @@ packages:
   merge-anything@5.1.7:
     resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
     engines: {node: '>=12.13'}
+
+  microformats-parser@2.0.6:
+    resolution: {integrity: sha512-VTnLImF17yd+ZfBH40sddHMJp5Rrker4ge+oPjgnBQ3jluQO0YmsNVA4UcEfHRBV8zrikBSMkAzAub+nTRX85g==}
+    engines: {node: '>=18'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -5391,6 +5398,10 @@ snapshots:
   merge-anything@5.1.7:
     dependencies:
       is-what: 4.1.16
+
+  microformats-parser@2.0.6:
+    dependencies:
+      parse5: 7.3.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -49,9 +49,17 @@ if (title === site.title) {
   <!-- Mastodon -->
   <meta name="fediverse:creator" content="@candost@hachyderm.io" />
 
-  <!-- IndieAuth -->
+  <!-- IndieAuth / rel-me: mirrors the visible identity links in the footer -->
+  <link href="https://hachyderm.io/@candost" rel="me" />
   <link href="https://github.com/candostdagdeviren" rel="me" />
   <link href="https://linkedin.com/in/candost" rel="me" />
+  <link href="mailto:contact@candostdagdeviren.com" rel="me" />
+
+  <!--
+    Author discovery for microformats2 parsers: entries on this site have no
+    visible byline, so parsers follow rel="author" to the homepage h-card.
+  -->
+  <link href={new URL("/", Astro.site).href} rel="author" />
 
   <link rel="sitemap" href="/sitemap-0.xml" />
   <title>{title} | {site.title}</title>

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,6 +1,6 @@
 ---
 import "../styles/index.css";
-import { site } from "../consts";
+import { site, infoLinks } from "../consts";
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 const { mathjax = false, mermaid = false, title, description, ogImagePath } = Astro.props;
@@ -49,11 +49,12 @@ if (title === site.title) {
   <!-- Mastodon -->
   <meta name="fediverse:creator" content="@candost@hachyderm.io" />
 
-  <!-- IndieAuth / rel-me: mirrors the visible identity links in the footer -->
-  <link href="https://hachyderm.io/@candost" rel="me" />
-  <link href="https://github.com/candostdagdeviren" rel="me" />
-  <link href="https://linkedin.com/in/candost" rel="me" />
-  <link href="mailto:contact@candostdagdeviren.com" rel="me" />
+  <!--
+    IndieAuth / rel-me. Generated from the same infoLinks list that renders the
+    visible identity links in the footer, so the two cannot drift apart when a
+    profile is added or a handle changes.
+  -->
+  {infoLinks.filter((link) => link.me).map((link) => <link href={link.outlink} rel="me" />)}
 
   <!--
     Author discovery for microformats2 parsers: entries on this site have no

--- a/src/components/FeedPreview.astro
+++ b/src/components/FeedPreview.astro
@@ -2,12 +2,12 @@
 const { data, body, id } = Astro.props.post;
 ---
 
-<div>
+<div class="h-entry">
   <a
-    class="text-xl font-bold underline-offset-4 decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500"
+    class="text-xl font-bold underline-offset-4 decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500 p-name u-url"
     href={`${id}`}>{data.title}</a
   >
-  <p class="break-word first-letter tracking-wide">
+  <p class="break-word first-letter tracking-wide p-summary">
     {
       body.length > 140
         ? body

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -50,7 +50,9 @@ import { site, config, footerLinks, infoLinks } from "../consts";
             const external = link.outlink.startsWith("http");
             // rel is a space-separated token list, so "me noopener" still
             // registers as rel=me for microformats parsers.
-            const rel = [link.me && "me", external && "noopener"].filter(Boolean).join(" ");
+            const rel = [link.me && "me", external && "noopener noreferrer"]
+              .filter(Boolean)
+              .join(" ");
             return (
               <a
                 href={link.outlink}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -50,6 +50,7 @@ import { site, config, footerLinks, infoLinks } from "../consts";
             <a
               href={link.outlink}
               rel={link.me ? "me" : undefined}
+              target={link.outlink.startsWith("http") ? "_blank" : undefined}
               class="hover:text-skin-active"
               title={link.name}
               aria-label={link.name}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -46,18 +46,24 @@ import { site, config, footerLinks, infoLinks } from "../consts";
       -->
       <div class="flex justify-center items-center gap-4 mb-5 text-2xl">
         {
-          infoLinks.map((link) => (
-            <a
-              href={link.outlink}
-              rel={link.me ? "me" : undefined}
-              target={link.outlink.startsWith("http") ? "_blank" : undefined}
-              class="hover:text-skin-active"
-              title={link.name}
-              aria-label={link.name}
-            >
-              <i class={link.icon} />
-            </a>
-          ))
+          infoLinks.map((link) => {
+            const external = link.outlink.startsWith("http");
+            // rel is a space-separated token list, so "me noopener" still
+            // registers as rel=me for microformats parsers.
+            const rel = [link.me && "me", external && "noopener"].filter(Boolean).join(" ");
+            return (
+              <a
+                href={link.outlink}
+                rel={rel || undefined}
+                target={external ? "_blank" : undefined}
+                class="hover:text-skin-active"
+                title={link.label}
+                aria-label={link.label}
+              >
+                <i class={link.icon} />
+              </a>
+            );
+          })
         }
       </div>
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { site, config, footerLinks } from "../consts";
+import { site, config, footerLinks, infoLinks } from "../consts";
 ---
 
 <div class="footer container p-4">
@@ -38,6 +38,28 @@ import { site, config, footerLinks } from "../consts";
           </ul>
         </div>
       </div>
+      <div class="divider-horizontal"></div>
+
+      <!--
+        Identity links. The ones flagged `me` carry rel="me" so services like
+        Mastodon can verify this domain (they link back here the same way).
+      -->
+      <div class="flex justify-center items-center gap-4 mb-5 text-2xl">
+        {
+          infoLinks.map((link) => (
+            <a
+              href={link.outlink}
+              rel={link.me ? "me" : undefined}
+              class="hover:text-skin-active"
+              title={link.name}
+              aria-label={link.name}
+            >
+              <i class={link.icon} />
+            </a>
+          ))
+        }
+      </div>
+
       <div class="divider-horizontal"></div>
       <div class="mb-5">
         All content on this website is licensed under

--- a/src/components/NotesTitle.astro
+++ b/src/components/NotesTitle.astro
@@ -13,7 +13,7 @@ const { title, tags } = Astro.props;
   </p>
   </div>
   <!-- title -->
-  <h1 class="break-all text-xl font-bold my-2" style="white-space:pre-wrap; word-break:break-word;">{title}</h1>
+  <h1 class="break-all text-xl font-bold my-2 p-name" style="white-space:pre-wrap; word-break:break-word;">{title}</h1>
 
   <div class="flex flex-wrap items-center my-2">
     {

--- a/src/components/PostTitle.astro
+++ b/src/components/PostTitle.astro
@@ -5,7 +5,7 @@ const {title, category } = Astro.props
 
 <div>
   <!-- title -->
-  <h1 class="break-all text-xl font-bold" style="white-space:pre-wrap; word-break:break-word;">{title}</h1>
+  <h1 class="break-all text-xl font-bold p-name" style="white-space:pre-wrap; word-break:break-word;">{title}</h1>
 
   <div class="flex flex-wrap items-center my-2 space-x-2">
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -147,9 +147,8 @@ export const footerLinks = [
 ];
 
 /**
- * Personal link address
- */
-/**
+ * Personal link addresses.
+ *
  * `me` marks a link as an identity link, rendered with rel="me" so other
  * services can tie the profile to this domain.
  *
@@ -164,30 +163,35 @@ export const infoLinks = [
   {
     icon: "ri-mastodon-fill",
     name: "mastodon",
+    label: "Mastodon",
     outlink: "https://hachyderm.io/@candost",
     me: true,
   },
   {
     icon: "ri-linkedin-fill",
     name: "linkedin",
+    label: "LinkedIn",
     outlink: "https://linkedin.com/in/candost",
     me: true,
   },
   {
     icon: "ri-github-fill",
     name: "github",
+    label: "GitHub",
     outlink: "https://github.com/candostdagdeviren",
     me: true,
   },
   {
     icon: "ri-mail-fill",
     name: "email",
+    label: "Email",
     outlink: "mailto:contact@candostdagdeviren.com",
     me: true,
   },
   {
     icon: "ri-rss-fill",
     name: "rss",
+    label: "RSS",
     outlink: "/feeds",
     me: false,
   },

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -149,26 +149,42 @@ export const footerLinks = [
 /**
  * Personal link address
  */
+/**
+ * `me` marks a link as an identity link. Those are rendered with rel="me" so
+ * that other services can verify the profile belongs to this domain. The
+ * verification is reciprocal: the profile on the other end has to link back
+ * here, also with rel="me".
+ */
 export const infoLinks = [
+  {
+    icon: "ri-mastodon-fill",
+    name: "mastodon",
+    outlink: "https://hachyderm.io/@candost",
+    me: true,
+  },
   {
     icon: "ri-linkedin-fill",
     name: "linkedin",
     outlink: "https://linkedin.com/in/candost",
+    me: true,
   },
   {
     icon: "ri-github-fill",
     name: "github",
     outlink: "https://github.com/candostdagdeviren",
-  },
-  {
-    icon: "ri-rss-fill",
-    name: "rss",
-    outlink: "/feeds",
+    me: true,
   },
   {
     icon: "ri-mail-fill",
     name: "email",
     outlink: "mailto:contact@candostdagdeviren.com",
+    me: true,
+  },
+  {
+    icon: "ri-rss-fill",
+    name: "rss",
+    outlink: "/feeds",
+    me: false,
   },
 ];
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -150,10 +150,15 @@ export const footerLinks = [
  * Personal link address
  */
 /**
- * `me` marks a link as an identity link. Those are rendered with rel="me" so
- * that other services can verify the profile belongs to this domain. The
- * verification is reciprocal: the profile on the other end has to link back
- * here, also with rel="me".
+ * `me` marks a link as an identity link, rendered with rel="me" so other
+ * services can tie the profile to this domain.
+ *
+ * For profile URLs (Mastodon, GitHub, LinkedIn) verification is reciprocal:
+ * the profile on the other end has to link back here, also with rel="me" —
+ * that is what earns Mastodon's verified checkmark. The mailto: link is a
+ * valid rel="me" identity too, but an address cannot link back, so it is
+ * confirmed through a separate opt-in flow (e.g. IndieAuth email auth)
+ * rather than by reciprocity.
  */
 export const infoLinks = [
   {

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -33,7 +33,9 @@ const { frontmatter = { comment: false } } = Astro.props;
     // Only mark up links that actually leave the site. Internal links keep
     // their default rel so search engines can follow them; `hostname` is
     // empty for mailto:, javascript: and anchor-less links, which skips
-    // those too. Mirrors the external-only check in BlogPost.astro.
+    // those too. Same goal as the outbound-link handling in BlogPost.astro,
+    // though that one is scoped to .markdown-body and compares the href
+    // prefix rather than the hostname.
     if (item.hostname && item.hostname !== window.location.hostname) {
       item.setAttribute("rel", "nofollow noreferrer");
     }

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -29,7 +29,14 @@ const { frontmatter = { comment: false } } = Astro.props;
     // author discovery), so leave those links untouched.
     const rel = item.getAttribute("rel");
     if (rel && /\b(me|author)\b/.test(rel)) return;
-    item.setAttribute("rel", "nofollow noreferrer");
+
+    // Only mark up links that actually leave the site. Internal links keep
+    // their default rel so search engines can follow them; `hostname` is
+    // empty for mailto:, javascript: and anchor-less links, which skips
+    // those too. Mirrors the external-only check in BlogPost.astro.
+    if (item.hostname && item.hostname !== window.location.hostname) {
+      item.setAttribute("rel", "nofollow noreferrer");
+    }
   });
 </script>
 </html>

--- a/src/layouts/IndexPage.astro
+++ b/src/layouts/IndexPage.astro
@@ -25,6 +25,10 @@ const { frontmatter = { comment: false } } = Astro.props;
 </body>
 <script>
   document.body.querySelectorAll("a").forEach(item => {
+    // rel="me" and rel="author" carry meaning (identity verification and
+    // author discovery), so leave those links untouched.
+    const rel = item.getAttribute("rel");
+    if (rel && /\b(me|author)\b/.test(rel)) return;
     item.setAttribute("rel", "nofollow noreferrer");
   });
 </script>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -29,11 +29,13 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, entry);
 <BlogPost frontmatter={{ comment: true, ...entry.data }}>
   <div>
     <p class="text-sm italic mb-3"><i class="ri-pen-nib-line mr-2 mt-2"></i><a href="/posts">Essay</a></p>
-    <PostTitle {...entry.data} />
-    <div class="divider-horizontal"></div>
-    <article class="markdown-body">
-      <Content />
-    </article>
+    <div class="h-entry">
+      <PostTitle {...entry.data} />
+      <div class="divider-horizontal"></div>
+      <article class="markdown-body e-content">
+        <Content />
+      </article>
+    </div>
     <div class="divider-horizontal"></div>
     <PostNavigation prevPost={prevPost} nextPost={nextPost} />
     <BlogFooter

--- a/src/pages/books/[book].astro
+++ b/src/pages/books/[book].astro
@@ -29,11 +29,13 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, entry);
 <BlogPost frontmatter={{ comment: true, ...entry.data }}>
   <div>
     <p class="text-sm italic mb-3"><i class="ri-book-line mr-2 mt-2"></i><a href="/books">Book</a></p>
-    <PostTitle {...entry.data} />
-    <div class="divider-horizontal"></div>
-    <article class="markdown-body">
-      <Content />
-    </article>
+    <div class="h-entry">
+      <PostTitle {...entry.data} />
+      <div class="divider-horizontal"></div>
+      <article class="markdown-body e-content">
+        <Content />
+      </article>
+    </div>
     <div class="divider-horizontal"></div>
     <PostNavigation prevPost={prevPost} nextPost={nextPost} />
     <BlogFooter

--- a/src/pages/books/index.astro
+++ b/src/pages/books/index.astro
@@ -17,20 +17,18 @@ let sortedPosts = sortPostsAlphabetically(posts);
 
   <div class="divider-horizontal"/>
   <div>
-    <ul>
+    <ul class="h-feed">
       {
         sortedPosts.map((post) => (
-        <div>
-          <li class="mb-3 content-item" data-collection={post.collection} style="display: list-item;">
+          <li class="mb-3 content-item h-entry" data-collection={post.collection} style="display: list-item;">
             <i class="ri-book-line mr-2 mt-2 text-xl" />
               <strong>
-                <a class="underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500" href={'/books/' + post.id}>
+                <a class="underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500 p-name u-url" href={'/books/' + post.id}>
                   {post.data.title}
                 </a>
               </strong>
 
           </li>
-        </div>
         ))
       }
     </ul>

--- a/src/pages/de/[slug].astro
+++ b/src/pages/de/[slug].astro
@@ -28,11 +28,13 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, entry);
 
 <BlogPost frontmatter={entry.data}>
   <div>
-    <PostTitle {...entry.data} />
-    <div class="divider-horizontal"></div>
-    <article class="markdown-body">
-      <Content />
-    </article>
+    <div class="h-entry">
+      <PostTitle {...entry.data} />
+      <div class="divider-horizontal"></div>
+      <article class="markdown-body e-content">
+        <Content />
+      </article>
+    </div>
     <div class="divider-horizontal"></div>
     <PostNavigation prevPost={prevPost} nextPost={nextPost} />
     <BlogFooter

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,20 +15,27 @@ let resultPosts = favorites.splice(0, site.favoritePostsSize);
 ---
 
 <BlogPost frontmatter={{ comment: false, title: "Home" }}>
-  <section class="mb-8">
+  <!--
+    h-card: the machine-readable identity for this domain. Parsers (and
+    services like Bridgy Fed) read it to know who publishes here, and
+    rel="author" in the document head points at this page to find it.
+  -->
+  <section class="mb-8 h-card">
     <div class="pt-4 pb-4">
-      <p class="text-4xl">Candost</p>
-      <p class="text-sm italic">Software Engineering Leader, Writer, Problem Solver</p>
+      <p class="text-4xl"><a class="p-name u-url u-uid" href={`${site.url}/`}>Candost</a></p>
+      <p class="text-sm italic p-job-title">Software Engineering Leader, Writer, Problem Solver</p>
     </div>
-    <p class="mb-2">
-      I work towards creating great, high-performing systems and technology organizations by identifying <em
-        >the real problems</em
-      >.
+    <div class="p-note">
+      <p class="mb-2">
+        I work towards creating great, high-performing systems and technology organizations by identifying <em
+          >the real problems</em
+        >.
+      </p>
       <p class="mb-5">
         On this website, I'm hunting timeless insights into humans, software, and leadership, bringing solutions along
         the way.
       </p>
-    </p>
+    </div>
 
     <a href="/about/">
       <i class="ri-arrow-right-line"></i>

--- a/src/pages/journal/[entry].astro
+++ b/src/pages/journal/[entry].astro
@@ -27,28 +27,26 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, post);
 ---
 
 <BlogPost frontmatter={{comment:true, ...post.data}}>
-  {
-    (
-    <p class="text-sm italic mb-3"><i class="ri-chat-thread-line mr-2 mt-2" /><a href="/journal">Journal</a></p>
+  <p class="text-sm italic mb-3"><i class="ri-chat-thread-line mr-2 mt-2" /><a href="/journal">Journal</a></p>
+  <div class="h-entry">
     <PostTitle {...post.data}></PostTitle>
     <div class="flex items-center mb-2">
       {comment.enable && comment.type === "waline" && comment.pageview}
     </div>
-    )
-  }
-  {post.data.externalUrl && (
-    <p class="text-sm mb-2">
-      <span>In response to: </span>
-      <a href={post.data.externalUrl} target="_blank" rel="noopener noreferrer"
-         class="header-link-active underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500">
-        <i class="ri-external-link-line" /> {post.data.externalTitle || post.data.externalUrl}
-      </a>
-    </p>
-  )}
-  <div class="divider-horizontal"></div>
-  <article class="markdown-body scroll-smooth mb-4">
-    <Content/>
-  </article>
+    {post.data.externalUrl && (
+      <p class="text-sm mb-2">
+        <span>In response to: </span>
+        <a href={post.data.externalUrl} target="_blank" rel="noopener noreferrer"
+           class="header-link-active underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500">
+          <i class="ri-external-link-line" /> {post.data.externalTitle || post.data.externalUrl}
+        </a>
+      </p>
+    )}
+    <div class="divider-horizontal"></div>
+    <article class="markdown-body scroll-smooth mb-4 e-content">
+      <Content/>
+    </article>
+  </div>
   <div class="divider-horizontal"></div>
   <PostNavigation prevPost={prevPost} nextPost={nextPost} />
   <BlogFooter

--- a/src/pages/journal/index.astro
+++ b/src/pages/journal/index.astro
@@ -18,5 +18,7 @@ posts = sortPostsByDate(posts);
   <p class="mb-10">You can get new entries in your favorite RSS reader via <a class="truncate mt-1 header-link-active cursor-pointer decoration-skin-base hover:text-skin-active" href="/journal/rss.xml">the dedicated RSS feed</a>.</p>
   <div class="divider-horizontal"/>
 
-  {posts.map((post, index) => <FeedPreview post={post} index={index} />)}
+  <div class="h-feed">
+    {posts.map((post, index) => <FeedPreview post={post} index={index} />)}
+  </div>
 </IndexPage>

--- a/src/pages/newsletter/[...slug].astro
+++ b/src/pages/newsletter/[...slug].astro
@@ -25,11 +25,13 @@ const { Content } = await render(entry);
     <p class="text-sm italic mb-3">
       <i class="ri-pen-nib-line mr-2 mt-2"></i><a href="/newsletter">Newsletter Issue</a>
     </p>
-    <PostTitle {...entry.data} />
-    <div class="divider-horizontal"></div>
-    <article class="markdown-body">
-      <Content />
-    </article>
+    <div class="h-entry">
+      <PostTitle {...entry.data} />
+      <div class="divider-horizontal"></div>
+      <article class="markdown-body e-content">
+        <Content />
+      </article>
+    </div>
     <div class="divider-horizontal"></div>
     <BlogFooter
       title={entry.data.title}

--- a/src/pages/notes/[note].astro
+++ b/src/pages/notes/[note].astro
@@ -55,11 +55,13 @@ const backlinks = allLinks[pathname] || [];
 
 <BlogPost frontmatter={entry.data}>
   <div>
-    <NotesTitle {...entry.data} title={`${entry.data.zettelId}: ${entry.data.title}`} />
-    <div class="divider-horizontal"></div>
-    <article class="markdown-body">
-      <Content />
-    </article>
+    <div class="h-entry">
+      <NotesTitle {...entry.data} title={`${entry.data.zettelId}: ${entry.data.title}`} />
+      <div class="divider-horizontal"></div>
+      <article class="markdown-body e-content">
+        <Content />
+      </article>
+    </div>
 
     <PostNavigation
       class="mt-10"

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -33,13 +33,13 @@ let sortedNotes = sortNotesByZettelId(zettels);
   <h2 class="text-2xl fa-2x mb-5 mt-10">All Notes</h2>
   <p class="fa-m mb-10 mt-10"><em>Here are all notes are ordered squentially by their Zettel numbers, not chronologically.</em></p>
   <div>
-    <ul>
+    <ul class="h-feed">
       {
         sortedNotes
         .map((post) => (
-        <li style="list-style-type: disc;" class="ml-4 my-2">
-          <a class="flex text-l" href={'/notes/' + post.id}>
-            <span class="underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500"><strong>{post.data.zettelId}:&nbsp;</strong>{post.data.title}</span>
+        <li style="list-style-type: disc;" class="ml-4 my-2 h-entry">
+          <a class="flex text-l u-url" href={'/notes/' + post.id}>
+            <span class="underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500 p-name"><strong>{post.data.zettelId}:&nbsp;</strong>{post.data.title}</span>
           </a>
         </li>
         )

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -13,13 +13,13 @@ let sortedPosts = sortPostsByDate(posts.concat(newsletter));
   <h1 class="text-3xl mb-5 font-bold">Essays.</h1>
   You can get new posts in your favorite RSS reader via <a class="truncate mt-1 header-link-active cursor-pointer decoration-skin-base hover:text-skin-active" href="/posts/rss.xml">the dedicated RSS feed.</a>
   <div>
-    <ul>
+    <ul class="h-feed">
   {
     sortedPosts.map((post) => (
-      <li class="mb-3 content-item" data-collection={post.collection} style="display: list-item;">
+      <li class="mb-3 content-item h-entry" data-collection={post.collection} style="display: list-item;">
         <i class="ri-pen-nib-line mr-2 mt-2 text-lg" />
         <a
-          class="underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500"
+          class="underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500 p-name u-url"
           href={post.collection === "posts" ? `/${post.id}/` : `/${post.collection}/${post.id}/`}
         >
           <strong class="text-lg">{post.data.title}</strong>

--- a/tests/microformats.test.mjs
+++ b/tests/microformats.test.mjs
@@ -1,0 +1,204 @@
+/**
+ * Structural checks for the IndieWeb microformats2 markup.
+ *
+ * These run against the *built* output in dist/, not the source templates,
+ * because microformats are a property of the emitted HTML — a refactor can
+ * keep every .astro file looking fine while quietly dropping a class.
+ *
+ * Run `pnpm build` first, then `pnpm test`.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mf2 } from "microformats-parser";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DIST = join(ROOT, "dist");
+const SITE = "https://candost.blog";
+
+if (!existsSync(DIST)) {
+  throw new Error(`No dist/ found at ${DIST}. Run \`pnpm build\` before \`pnpm test\`.`);
+}
+
+const trim = (p) => p.replace(/^\/+|\/+$/g, "");
+const urlFor = (relPath) => (trim(relPath) ? `${SITE}/${trim(relPath)}/` : `${SITE}/`);
+
+/** Parse a built page. `relPath` is dist-relative, e.g. "" or "posts". */
+const parsePage = (relPath) => {
+  const file = join(DIST, trim(relPath), "index.html");
+  assert.ok(existsSync(file), `expected a built page at /${trim(relPath)}/`);
+  return mf2(readFileSync(file, "utf-8"), { baseUrl: urlFor(relPath) });
+};
+
+const rootsOfType = (parsed, type) => parsed.items.filter((i) => (i.type ?? []).includes(type));
+const prop = (item, name) => item.properties?.[name] ?? [];
+/** rel values are space-separated token lists, so match tokens not strings. */
+const hasRelToken = (parsed, url, token) =>
+  (parsed["rel-urls"]?.[url]?.rels ?? []).includes(token);
+
+/** Map an absolute in-site URL back to a dist-relative path. */
+const pathFromUrl = (url) => trim(new URL(url).pathname);
+
+/** Every built page directly under a directory. */
+const allPagesUnder = (relDir) => {
+  const dir = join(DIST, trim(relDir));
+  assert.ok(existsSync(dir), `expected a built directory at /${trim(relDir)}/`);
+  const names = readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && existsSync(join(dir, d.name, "index.html")))
+    .map((d) => `${trim(relDir)}/${d.name}`);
+  assert.ok(names.length > 0, `no built pages under /${trim(relDir)}/`);
+  return names;
+};
+
+/** Entries listed by an h-feed, as dist-relative paths. */
+const entriesInFeed = (relPath) => {
+  const feed = rootsOfType(parsePage(relPath), "h-feed")[0];
+  assert.ok(feed, `expected an h-feed on /${trim(relPath)}/`);
+  return (feed.children ?? [])
+    .filter((c) => (c.type ?? []).includes("h-entry"))
+    .map((c) => prop(c, "url")[0])
+    .filter(Boolean)
+    .map(pathFromUrl);
+};
+
+const LISTING_PAGES = ["posts", "notes", "journal", "books"];
+
+// -------------------------------------------------------------------------
+
+describe("h-card — homepage identity", () => {
+  const home = parsePage("");
+
+  test("exactly one h-card is published", () => {
+    assert.equal(rootsOfType(home, "h-card").length, 1);
+  });
+
+  test("carries a name and a url", () => {
+    const card = rootsOfType(home, "h-card")[0];
+    assert.equal(prop(card, "name")[0], "Candost");
+    assert.equal(prop(card, "url")[0], `${SITE}/`);
+  });
+});
+
+describe("rel=me / rel=author — identity links", () => {
+  const EXPECTED_ME = [
+    "https://hachyderm.io/@candost",
+    "https://github.com/candostdagdeviren",
+    "https://linkedin.com/in/candost",
+    "mailto:contact@candostdagdeviren.com",
+  ];
+
+  // The homepage uses BlogPost.astro and listing pages use IndexPage.astro.
+  // Checking both guards against the two layouts drifting apart.
+  for (const [label, page] of [
+    ["homepage (BlogPost layout)", ""],
+    ["/posts/ (IndexPage layout)", "posts"],
+  ]) {
+    test(`${label} publishes every rel=me identity link`, () => {
+      const parsed = parsePage(page);
+      for (const url of EXPECTED_ME) {
+        assert.ok(
+          (parsed.rels.me ?? []).includes(url),
+          `${url} missing from rel=me on ${label}`,
+        );
+        assert.ok(hasRelToken(parsed, url, "me"), `${url} lost its "me" rel token`);
+      }
+    });
+  }
+
+  test("rel=author points at the homepage h-card", () => {
+    // Entries carry no visible byline, so parsers rely on this to find the author.
+    assert.ok((parsePage("").rels.author ?? []).includes(`${SITE}/`));
+  });
+});
+
+describe("h-entry — content pages", () => {
+  // Every entry page is checked, not a sample. Templates are shared, so one
+  // page per collection would catch a template regression — but not a page
+  // whose own content breaks the markup, and not a template that only some
+  // entries use. Parsing the whole site costs a few seconds.
+  //
+  // Paths come from the feeds (which list every post, note, journal entry and
+  // book note) so renaming or adding content never needs a test edit.
+  const collections = {
+    "essays + newsletter": entriesInFeed("posts"),
+    notes: entriesInFeed("notes"),
+    journal: entriesInFeed("journal"),
+    books: entriesInFeed("books"),
+    german: allPagesUnder("de"),
+  };
+
+  for (const [kind, paths] of Object.entries(collections)) {
+    describe(`${kind} (${paths.length} pages)`, () => {
+      test("pages were discovered", () => {
+        assert.ok(paths.length > 0, `no ${kind} pages found to check`);
+      });
+
+      test("every page publishes exactly one h-entry", () => {
+        const bad = paths.filter((p) => rootsOfType(parsePage(p), "h-entry").length !== 1);
+        assert.deepEqual(bad, [], `pages without exactly one h-entry: ${bad.join(", ")}`);
+      });
+
+      test("every h-entry has a non-empty p-name", () => {
+        const bad = paths.filter((p) => {
+          const entry = rootsOfType(parsePage(p), "h-entry")[0];
+          return !entry || !prop(entry, "name")[0]?.trim();
+        });
+        assert.deepEqual(bad, [], `pages missing p-name: ${bad.join(", ")}`);
+      });
+
+      test("every h-entry has non-empty e-content", () => {
+        const bad = paths.filter((p) => {
+          const entry = rootsOfType(parsePage(p), "h-entry")[0];
+          return !entry || !prop(entry, "content")[0]?.value?.trim();
+        });
+        assert.deepEqual(bad, [], `pages missing e-content: ${bad.join(", ")}`);
+      });
+    });
+  }
+});
+
+describe("h-feed — listing pages", () => {
+  for (const page of LISTING_PAGES) {
+    describe(`/${page}/`, () => {
+      test("publishes exactly one h-feed", () => {
+        assert.equal(rootsOfType(parsePage(page), "h-feed").length, 1);
+      });
+
+      test("h-feed contains h-entry children", () => {
+        const feed = rootsOfType(parsePage(page), "h-feed")[0];
+        const children = (feed.children ?? []).filter((c) => (c.type ?? []).includes("h-entry"));
+        assert.ok(children.length > 0, `no h-entry children in /${page}/`);
+      });
+
+      test("every child h-entry has a p-name and u-url", () => {
+        const feed = rootsOfType(parsePage(page), "h-feed")[0];
+        for (const child of feed.children ?? []) {
+          if (!(child.type ?? []).includes("h-entry")) continue;
+          assert.ok(prop(child, "name")[0]?.trim(), `entry without p-name in /${page}/`);
+          assert.ok(prop(child, "url")[0], `entry without u-url in /${page}/`);
+        }
+      });
+    });
+  }
+});
+
+describe("h-feed — deliberate exclusions", () => {
+  // The homepage renders its cards twice (Recent + Most popular) and /blog/
+  // renders them again. Marking those up would emit duplicate h-entry items
+  // for the same posts, which is why h-feed is scoped to the pages above.
+  for (const [label, page] of [
+    ["homepage", ""],
+    ["/blog/", "blog"],
+  ]) {
+    test(`${label} deliberately publishes no h-feed`, () => {
+      assert.equal(
+        rootsOfType(parsePage(page), "h-feed").length,
+        0,
+        `${label} gained an h-feed — cards render more than once there, so this ` +
+          `would emit duplicate entries for the same posts.`,
+      );
+    });
+  }
+});

--- a/tests/microformats.test.mjs
+++ b/tests/microformats.test.mjs
@@ -81,7 +81,24 @@ describe("h-card — homepage identity", () => {
   });
 });
 
+/** hrefs of <a>/<link> elements whose rel contains the "me" token. */
+const relMeHrefsIn = (html) => {
+  const found = new Set();
+  for (const [tag] of html.matchAll(/<(?:a|link)\b[^>]*>/gi)) {
+    const rel = /\brel="([^"]*)"/i.exec(tag)?.[1] ?? "";
+    if (!rel.split(/\s+/).includes("me")) continue;
+    const href = /\bhref="([^"]*)"/i.exec(tag)?.[1];
+    if (href) found.add(href);
+  }
+  return found;
+};
+
 describe("rel=me / rel=author — identity links", () => {
+  // Deliberately hardcoded rather than imported from src/consts.ts. This is
+  // the independent statement of *which* identities should be published, so
+  // changing a handle is expected to fail here until updated on purpose.
+  // (It also can't be imported: .nvmrc pins Node 22.12, which needs a flag
+  // to load .ts files.)
   const EXPECTED_ME = [
     "https://hachyderm.io/@candost",
     "https://github.com/candostdagdeviren",
@@ -111,6 +128,30 @@ describe("rel=me / rel=author — identity links", () => {
     // Entries carry no visible byline, so parsers rely on this to find the author.
     assert.ok((parsePage("").rels.author ?? []).includes(`${SITE}/`));
   });
+
+  // The <head> links and the visible footer links are both generated from
+  // infoLinks, so they cannot drift today. This asserts that structurally
+  // rather than trusting it, in case the head is ever hand-written again.
+  for (const [label, page] of [
+    ["homepage", ""],
+    ["/posts/", "posts"],
+  ]) {
+    test(`${label} publishes the same rel=me set in <head> and in the footer`, () => {
+      const html = readFileSync(join(DIST, trim(page), "index.html"), "utf-8");
+      const headEnd = html.indexOf("</head>");
+      assert.ok(headEnd > -1, "no </head> found");
+
+      const inHead = relMeHrefsIn(html.slice(0, headEnd));
+      const inBody = relMeHrefsIn(html.slice(headEnd));
+
+      assert.deepEqual(
+        [...inHead].sort(),
+        [...inBody].sort(),
+        `<head> and footer rel=me links disagree on ${label} — they should both ` +
+          `come from infoLinks in src/consts.ts`,
+      );
+    });
+  }
 });
 
 describe("h-entry — content pages", () => {


### PR DESCRIPTION
Tier 1 of the IndieWeb audit, following [Andros Fenollosa's "I joined the IndieWeb, here's what I learned"](https://en.andros.dev/blog/0b8e451e/i-joined-the-indieweb-heres-what-i-learned/). Mostly the machine-readable layer — no new pages, no parallel data files, no visual redesign — plus a test suite so it can't silently rot, and two bug fixes found along the way.

Publication dates (`dt-published`) are **intentionally excluded** and will follow separately.

## Microformats

### h-card — homepage identity
The identity block on `/` becomes an `h-card` with `p-name`, `u-url`/`u-uid`, `p-job-title`, and `p-note`. This is what lets other sites show your name next to a webmention from you, and it's the prerequisite for Bridgy Fed.

### h-entry — all six content types
Wraps title + content on essays, journal entries, Zettelkasten notes, book notes, newsletter issues, and German posts. `p-name` on titles, `e-content` on the rendered body. Post navigation and the reply footer sit **outside** the `h-entry` so parsers don't treat prev/next links as part of the post.

Entries have no visible byline, so rather than inject hidden author markup, a `rel="author"` link in `<head>` points parsers at the homepage h-card — the documented microformats2 author-discovery fallback.

### h-feed — dedicated listing pages only
Added to `/posts/`, `/notes/`, `/journal/`, and `/books/`, each child carrying `p-name` and `u-url`.

Deliberately **not** on the homepage or `/blog/`. Both render the same card markup more than once (Recent + Most popular on the homepage, and again under `/blog/`), which would produce ambiguous duplicate `h-entry` items. Fenollosa hit exactly this and dropped h-feed entirely for it; scoping it to single-render pages keeps the benefit without the ambiguity. There's a test asserting this absence so it doesn't get "fixed" later.

### rel="me" — identity verification
`infoLinks` in `src/consts.ts` was defined but never rendered anywhere. It now backs a visible row of identity links in the footer, with Mastodon added alongside GitHub / LinkedIn / email, and **the `<head>` links are generated from that same list** so the two can't drift.

> Verification is reciprocal for the profile URLs — the Hachyderm profile needs a link back to `candost.blog` for the green checkmark. That's a one-time profile-settings change, not code. The `mailto:` identity is confirmed through a separate opt-in flow instead, since an address can't link back.

### RSS is untouched
The IndieWeb treats RSS as a "maintenance tax," but the article's own conclusion is "h-feed for the IndieWeb and RSS/Atom for the rest of the planet." All seven feeds stay as they are.

## Bug fixes found along the way

**Internal links were being nofollowed site-wide on listing pages.** `IndexPage.astro` ran an on-load script that rewrote *every* anchor's `rel` to `nofollow noreferrer` — not just outbound ones. On `/posts/` that was **248 of 259 links**: the whole nav, footer, and post list, telling search engines not to follow the site's own pages. Same on `/notes/`, `/journal/`, `/books/`, `/blog/`.

This surfaced because the same script would have stripped `rel="me"` off the new footer links. The fix covers both: skip `rel="me"`/`rel="author"`, and only mark links that actually leave the site. This is a broader behavior change than rel=me preservation alone — flagging it explicitly so a future bisect doesn't read it as accidental scope creep.

**Two pieces of invalid HTML that broke microformats parsing:** a nested `<p>` in the homepage identity block (browsers auto-close it, mangling the `p-note` subtree) and a `<div>` between `<ul>` and `<li>` on `/books/` (broke the h-feed's child structure).

## Tests

`tests/microformats.test.mjs` — 41 tests via Node's built-in `node:test` and `microformats-parser`. Deliberately a JS parser rather than Python's `mf2py`, so the toolchain stays Node-only and CI needs no Python.

Tests run against **built `dist/` output, not source templates** — microformats are a property of emitted HTML, so every `.astro` file can look correct while the output is wrong.

| Guards | |
|---|---|
| homepage h-card | resolves name + url |
| `rel=me` / `rel=author` | present on **both** layouts (BlogPost and IndexPage), so they can't drift apart |
| `<head>` vs footer `rel=me` | identical sets — catches a re-hardcoded head |
| every entry page | exactly one h-entry, non-empty `p-name` and `e-content` |
| all four h-feeds | h-entry children carrying `p-name` + `u-url` |
| homepage and `/blog/` | still publish **no** h-feed |

Entry paths are discovered from the feeds, so adding or renaming content never needs a test edit. Every entry page is checked rather than one sample per collection — parsing all 1072 pages costs ~5s, which is cheaper than the blind spot.

CI: `.github/workflows/test.yml` installs, builds, then tests, scoped to `permissions: contents: read`.

## Verification

`pnpm build` succeeds (979 pages) and the suite passes in CI — [confirmed from the job logs](https://github.com/candostdagdeviren/candost.blog-astro/actions/runs/31357116067/job/93358771363), not just locally: `# tests 41 / # pass 41 / # fail 0`.

The assertions were checked for false confidence by deliberately breaking the built output four ways — dropping `e-content` from one essay, removing an `h-feed` class, repointing a `rel="me"` link, and deleting a single `<head>` link. Each produced a red test naming the offending page. (The first version of the suite sampled one page per collection and *missed* the first of those; that's why it now checks every page.)

The internal-link `nofollow` change is runtime DOM mutation the dist-based suite can't cover, so it was verified separately in headless Chromium across all four listing pages: 0 internal links nofollowed, 7 outbound retained on each.

`pnpm check` fails, but identically on clean `main` — TypeScript 7.0.2 doesn't expose the API `astro check` needs ([withastro/roadmap#1321](https://github.com/withastro/roadmap/discussions/1321)). Pre-existing, unrelated to this diff.

## Deliberately deferred

- **`dt-published`** — excluded by request. h-entry is less useful to webmention receivers and Bridgy Fed without it, so it's the natural next step whenever dates get displayed.
- **`u-photo` on the h-card** — would require showing the avatar on the homepage, a visible design change. Valid without it, but the photo won't appear next to posts in others' webmention displays until added.
- **`u-url` on individual entry pages** — omitted rather than adding invisible `<data>` elements, since hidden metadata cuts against the "publish visible data" principle. Listing entries carry it, where a real link exists.
- **Node 20 deprecation warnings** on `actions/checkout@v4` / `setup-node@v4` / `pnpm/action-setup@v4` — affects the pre-existing workflows identically, so it's a repo-wide bump rather than part of this PR.

## Not in this batch

Tier 2 onward: Webmention (send + receive), `u-in-reply-to` on journal entries, Bridgy backfeed, Bridgy Fed. All depend on this markup landing first.