### PR TITLE
Receive and display webmentions, mark up journal reply context

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "test": "node --test \"tests/**/*.test.mjs\"",
-    "test:build": "astro build && node --test \"tests/**/*.test.mjs\"",
+    "test": "node --experimental-strip-types --test \"tests/**/*.test.mjs\"",
+    "test:build": "astro build && pnpm test",
     "astro": "astro"
   },
   "dependencies": {

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,6 +1,6 @@
 ---
 import "../styles/index.css";
-import { site, infoLinks } from "../consts";
+import { site, infoLinks, webmentionEndpoint, webmentionPingback } from "../consts";
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 const { mathjax = false, mermaid = false, title, description, ogImagePath } = Astro.props;
@@ -61,6 +61,14 @@ if (title === site.title) {
     visible byline, so parsers follow rel="author" to the homepage h-card.
   -->
   <link href={new URL("/", Astro.site).href} rel="author" />
+
+  <!--
+    Webmention endpoints. A sending site fetches a page here, finds these, and
+    POSTs source + target to them. webmention.io receives on our behalf since
+    this site is static. Pingback is the older protocol, kept for reach.
+  -->
+  <link href={webmentionEndpoint} rel="webmention" />
+  <link href={webmentionPingback} rel="pingback" />
 
   <link rel="sitemap" href="/sitemap-0.xml" />
   <title>{title} | {site.title}</title>

--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -1,0 +1,127 @@
+---
+import {
+  getWebmentions,
+  mentionsFor,
+  safeExternalUrl,
+  displayName,
+  REACTION_PROPERTIES,
+  RESPONSE_PROPERTIES,
+  type Webmention,
+} from "../utils/getWebmentions";
+import { formatDate } from "../utils/formatDate";
+
+/**
+ * Mentions this page received from other sites, shown as a reference list.
+ *
+ * Kept separate from the comment section on purpose: comments are replies
+ * left here, these are links from someone else's own site. Only the plain-text
+ * content is rendered and every href is scheme-checked, because this is
+ * third-party data.
+ */
+
+const target = new URL(Astro.url.pathname, Astro.site).href;
+const mentions = mentionsFor(await getWebmentions(), target);
+
+const isProperty = (mention: Webmention, list: readonly string[]) =>
+  list.includes(mention["wm-property"] ?? "");
+
+// Likes and reposts are counted; replies and mentions are quoted.
+const reactions = mentions.filter((m) => isProperty(m, REACTION_PROPERTIES));
+const responses = mentions
+  .filter((m) => isProperty(m, RESPONSE_PROPERTIES))
+  .sort((a, b) => (a["wm-received"] ?? "").localeCompare(b["wm-received"] ?? ""));
+
+const LABELS: Record<string, string> = {
+  "in-reply-to": "replied",
+  "mention-of": "mentioned this",
+};
+
+const snippet = (mention: Webmention): string => {
+  // Deliberately the text, never content.html -- that is markup from a site
+  // we do not control.
+  const text = mention.content?.text?.trim();
+  if (!text) return "";
+  return text.length > 280 ? `${text.slice(0, 280).trimEnd()}…` : text;
+};
+---
+
+{
+  (reactions.length > 0 || responses.length > 0) && (
+    <section class="mt-8">
+      <div class="divider-horizontal" />
+      <h2 class="text-xl font-bold mb-1">Mentioned elsewhere.</h2>
+      <p class="text-sm italic mb-4">
+        Links to this page from other people's websites, collected via{" "}
+        <a
+          href="https://indieweb.org/Webmention"
+          class="colored-link hover:text-skin-active"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Webmention
+        </a>
+        .
+      </p>
+
+      {reactions.length > 0 && (
+        <p class="text-sm mb-4">
+          <i class="ri-heart-3-line mr-1" />
+          {reactions.length === 1 ? "1 like or repost" : `${reactions.length} likes and reposts`}
+          {" from "}
+          {reactions
+            .map((mention) => displayName(mention))
+            .filter((name, index, all) => all.indexOf(name) === index)
+            .join(", ")}
+          .
+        </p>
+      )}
+
+      {responses.length > 0 && (
+        <ul class="space-y-4">
+          {responses.map((mention) => {
+            const source = safeExternalUrl(mention["wm-source"] ?? mention.url);
+            const author = safeExternalUrl(mention.author?.url);
+            const name = displayName(mention);
+            const text = snippet(mention);
+            const when = mention.published || mention["wm-received"];
+
+            return (
+              <li class="text-sm">
+                <p class="mb-1">
+                  {author ? (
+                    <a
+                      href={author}
+                      class="font-bold colored-link hover:text-skin-active"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {name}
+                    </a>
+                  ) : (
+                    <strong>{name}</strong>
+                  )}
+                  <span> {LABELS[mention["wm-property"] ?? ""] ?? "linked here"}</span>
+                  {when && <span class="italic"> on {formatDate(when)}</span>}
+                  {source && (
+                    <>
+                      {" — "}
+                      <a
+                        href={source}
+                        class="colored-link hover:text-skin-active"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        read it <i class="ri-external-link-line" />
+                      </a>
+                    </>
+                  )}
+                </p>
+                {text && <blockquote class="italic opacity-90">{text}</blockquote>}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/src/components/Webmentions.astro
+++ b/src/components/Webmentions.astro
@@ -36,6 +36,16 @@ const LABELS: Record<string, string> = {
   "mention-of": "mentioned this",
 };
 
+/**
+ * Dates come from the sending site, so an unparseable one must not reach
+ * dayjs and render as "Invalid Date". Falls through to the time webmention.io
+ * received it.
+ */
+const usableDate = (value?: string | null): string | undefined => {
+  if (!value) return undefined;
+  return Number.isNaN(new Date(value).getTime()) ? undefined : value;
+};
+
 const snippet = (mention: Webmention): string => {
   // Deliberately the text, never content.html -- that is markup from a site
   // we do not control.
@@ -83,7 +93,7 @@ const snippet = (mention: Webmention): string => {
             const author = safeExternalUrl(mention.author?.url);
             const name = displayName(mention);
             const text = snippet(mention);
-            const when = mention.published || mention["wm-received"];
+            const when = usableDate(mention.published) ?? usableDate(mention["wm-received"]);
 
             return (
               <li class="text-sm">

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -209,7 +209,10 @@ export const infoLinks = [
  * as the WEBMENTION_IO_TOKEN environment variable at build time. Without it
  * the build still succeeds and simply renders no mentions.
  *
- * enable {boolean} render received mentions on entry pages
+ * enable {boolean} render received mentions on entry pages. This does NOT
+ *   gate endpoint discovery -- the rel="webmention" and rel="pingback" links
+ *   are always emitted, so mentions keep accumulating at webmention.io even
+ *   while display is switched off.
  * domain {string} the webmention.io account name; endpoints derive from it
  */
 export const webmention = {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -198,6 +198,29 @@ export const infoLinks = [
 ];
 
 /**
+ * Webmention
+ *
+ * Received mentions are handled by webmention.io, which accepts them on this
+ * site's behalf (a static site has no server to receive the POST). Sign in
+ * there with candost.blog -- the rel="me" links make that work -- and the
+ * endpoints below start collecting.
+ *
+ * Displaying them needs a read token from webmention.io's settings, supplied
+ * as the WEBMENTION_IO_TOKEN environment variable at build time. Without it
+ * the build still succeeds and simply renders no mentions.
+ *
+ * enable {boolean} render received mentions on entry pages
+ * domain {string} the webmention.io account name; endpoints derive from it
+ */
+export const webmention = {
+  enable: true,
+  domain: "candost.blog",
+};
+
+export const webmentionEndpoint = `https://webmention.io/${webmention.domain}/webmention`;
+export const webmentionPingback = `https://webmention.io/${webmention.domain}/xmlrpc`;
+
+/**
  * Comment Feature
  * enable {boolean}
  * type {string} required waline | giscus

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,13 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  /** webmention.io read token; without it the build renders no mentions. */
+  readonly WEBMENTION_IO_TOKEN?: string;
+  /** Overrides the webmention.io API base, for pointing a build at fixtures. */
+  readonly WEBMENTION_IO_API?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -7,6 +7,7 @@ import PostNavigation from "../components/PostNavigation.astro";
 import { getCollectionByName } from "../utils/getCollectionByName";
 import { sortPostsByDate } from "../utils/sortPostsByDate";
 import { getPrevNext } from "../utils/getPrevNext";
+import Webmentions from "../components/Webmentions.astro";
 
 export const prerender = true;
 
@@ -44,4 +45,5 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, entry);
       date={entry.data.date}
     />
   </div>
+  <Webmentions />
 </BlogPost>

--- a/src/pages/books/[book].astro
+++ b/src/pages/books/[book].astro
@@ -7,6 +7,7 @@ import PostNavigation from "../../components/PostNavigation.astro";
 import { getCollectionByName } from "../../utils/getCollectionByName";
 import { sortPostsByDate } from "../../utils/sortPostsByDate";
 import { getPrevNext } from "../../utils/getPrevNext";
+import Webmentions from "../../components/Webmentions.astro";
 
 export const prerender = true;
 
@@ -44,4 +45,5 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, entry);
       date={entry.data.date}
     />
   </div>
+  <Webmentions />
 </BlogPost>

--- a/src/pages/de/[slug].astro
+++ b/src/pages/de/[slug].astro
@@ -7,6 +7,7 @@ import PostNavigation from "../../components/PostNavigation.astro";
 import { getCollectionByName } from "../../utils/getCollectionByName";
 import { sortPostsByDate } from "../../utils/sortPostsByDate";
 import { getPrevNext } from "../../utils/getPrevNext";
+import Webmentions from "../../components/Webmentions.astro";
 
 export const prerender = true;
 
@@ -43,4 +44,5 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, entry);
       date={entry.data.date}
     />
   </div>
+  <Webmentions />
 </BlogPost>

--- a/src/pages/journal/[entry].astro
+++ b/src/pages/journal/[entry].astro
@@ -8,6 +8,7 @@ import { comment } from "../../consts";
 import PostTitle from "../../components/PostTitle.astro";
 import BlogFooter from "../../components/BlogFooter.astro";
 import PostNavigation from "../../components/PostNavigation.astro";
+import Webmentions from "../../components/Webmentions.astro";
 
 export const prerender = true;
 
@@ -36,8 +37,10 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, post);
     {post.data.externalUrl && (
       <p class="text-sm mb-2">
         <span>In response to: </span>
+        {/* u-in-reply-to marks this as a genuine reply, so a receiving site
+            can display it as one rather than a bare mention. */}
         <a href={post.data.externalUrl} target="_blank" rel="noopener noreferrer"
-           class="header-link-active underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500">
+           class="u-in-reply-to header-link-active underline-offset-4 cursor-pointer decoration-skin-base decoration-wavy hover:underline hover:decoration-sky-500">
           <i class="ri-external-link-line" /> {post.data.externalTitle || post.data.externalUrl}
         </a>
       </p>
@@ -54,4 +57,5 @@ const { prevPost, nextPost } = getPrevNext(sortPosts, post);
   url={post.collection == 'posts' ? post.id : post.collection + '/' + post.id}
   date={post.data.date}>
 </BlogFooter>
+  <Webmentions />
 </BlogPost>

--- a/src/pages/newsletter/[...slug].astro
+++ b/src/pages/newsletter/[...slug].astro
@@ -4,6 +4,7 @@ import BlogPost from "../../layouts/BlogPost.astro";
 import PostTitle from "../../components/PostTitle.astro";
 import BlogFooter from "../../components/BlogFooter.astro";
 import { getCollectionByName } from "../../utils/getCollectionByName";
+import Webmentions from "../../components/Webmentions.astro";
 
 export const prerender = true;
 
@@ -39,4 +40,5 @@ const { Content } = await render(entry);
       date={entry.data.date}
     />
   </div>
+  <Webmentions />
 </BlogPost>

--- a/src/pages/notes/[note].astro
+++ b/src/pages/notes/[note].astro
@@ -7,6 +7,7 @@ import { getCollectionByName } from "../../utils/getCollectionByName";
 import { sortNotesByZettelId } from "../../utils/sortNotesByZettelId";
 import { getPrevNext } from "../../utils/getPrevNext";
 import NotesFooter from "../../components/NotesFooter.astro";
+import Webmentions from "../../components/Webmentions.astro";
 
 export const prerender = true;
 
@@ -85,4 +86,5 @@ const backlinks = allLinks[pathname] || [];
     }
     <NotesFooter title={entry.data.title} url={entry.id} date={entry.data.date} />
   </div>
+  <Webmentions />
 </BlogPost>

--- a/src/utils/getWebmentions.ts
+++ b/src/utils/getWebmentions.ts
@@ -1,0 +1,94 @@
+import { webmention } from "../consts";
+import { normalizeTarget, type Webmention } from "./webmentionFormat";
+
+/**
+ * Fetches received webmentions from webmention.io at build time.
+ *
+ * Everything here degrades quietly: no token, an unreachable API, or a
+ * malformed response all produce zero mentions and a warning rather than a
+ * failed build. Publishing must never depend on a third-party service being
+ * up -- the mentions are an enhancement, not the content.
+ *
+ * The pure formatting and URL-safety helpers live in ./webmentionFormat and
+ * are re-exported here so components have a single import.
+ */
+export * from "./webmentionFormat";
+
+const DEFAULT_API = "https://webmention.io/api/mentions.jf2";
+const PER_PAGE = 500;
+/** Stop paging even if the API keeps returning full pages. */
+const MAX_PAGES = 20;
+
+// import.meta.env covers .env files loaded by Vite; process.env covers CI and
+// Netlify build environment variables.
+const readEnv = (name: string): string | undefined => {
+  const fromVite = (import.meta as any)?.env?.[name];
+  const fromNode = typeof process !== "undefined" ? process.env?.[name] : undefined;
+  return fromVite || fromNode || undefined;
+};
+
+const readToken = () => readEnv("WEBMENTION_IO_TOKEN");
+/** Overridable so a build can be pointed at fixture data instead of the live API. */
+const readApi = () => readEnv("WEBMENTION_IO_API") || DEFAULT_API;
+
+let cached: Map<string, Webmention[]> | null = null;
+
+/**
+ * All received mentions, grouped by normalised target URL. Fetched once per
+ * build and memoised, so every page reuses the same result.
+ */
+export const getWebmentions = async (): Promise<Map<string, Webmention[]>> => {
+  if (cached) return cached;
+
+  const grouped = new Map<string, Webmention[]>();
+  cached = grouped;
+
+  if (!webmention.enable) return grouped;
+
+  const token = readToken();
+  if (!token) {
+    console.warn(
+      "[webmention] WEBMENTION_IO_TOKEN is not set - building without received mentions.",
+    );
+    return grouped;
+  }
+
+  const api = readApi();
+  const collected: Webmention[] = [];
+  try {
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const url =
+        `${api}?domain=${encodeURIComponent(webmention.domain)}` +
+        `&token=${encodeURIComponent(token)}&per-page=${PER_PAGE}&page=${page}`;
+
+      const response = await fetch(url, { signal: AbortSignal.timeout(15000) });
+      if (!response.ok) {
+        console.warn(`[webmention] webmention.io responded ${response.status} - skipping.`);
+        break;
+      }
+
+      const body = (await response.json()) as { children?: Webmention[] };
+      const batch = Array.isArray(body?.children) ? body.children : [];
+      collected.push(...batch);
+
+      if (batch.length < PER_PAGE) break;
+    }
+  } catch (error) {
+    console.warn(
+      `[webmention] could not reach webmention.io (${(error as Error)?.message ?? error}) - building without received mentions.`,
+    );
+    return grouped;
+  }
+
+  for (const mention of collected) {
+    const target = mention["wm-target"];
+    if (!target) continue;
+    const key = normalizeTarget(target);
+    const list = grouped.get(key);
+    if (list) list.push(mention);
+    else grouped.set(key, [mention]);
+  }
+
+  console.info(`[webmention] ${collected.length} mention(s) across ${grouped.size} page(s).`);
+  return grouped;
+};

--- a/src/utils/getWebmentions.ts
+++ b/src/utils/getWebmentions.ts
@@ -1,23 +1,18 @@
 import { webmention } from "../consts";
+import { fetchWebmentions } from "./webmentionFetch";
 import { normalizeTarget, type Webmention } from "./webmentionFormat";
 
 /**
- * Fetches received webmentions from webmention.io at build time.
+ * Received webmentions, fetched once per build and grouped by target URL.
  *
- * Everything here degrades quietly: no token, an unreachable API, or a
- * malformed response all produce zero mentions and a warning rather than a
- * failed build. Publishing must never depend on a third-party service being
- * up -- the mentions are an enhancement, not the content.
- *
- * The pure formatting and URL-safety helpers live in ./webmentionFormat and
- * are re-exported here so components have a single import.
+ * The network half lives in ./webmentionFetch and the pure formatting and
+ * URL-safety helpers in ./webmentionFormat; both are re-exported here so
+ * components have a single import. Neither can throw, so this never fails a
+ * build -- mentions are an enhancement, not the content.
  */
 export * from "./webmentionFormat";
 
 const DEFAULT_API = "https://webmention.io/api/mentions.jf2";
-const PER_PAGE = 500;
-/** Stop paging even if the API keeps returning full pages. */
-const MAX_PAGES = 20;
 
 // import.meta.env covers .env files loaded by Vite; process.env covers CI and
 // Netlify build environment variables.
@@ -27,60 +22,17 @@ const readEnv = (name: string): string | undefined => {
   return fromVite || fromNode || undefined;
 };
 
-const readToken = () => readEnv("WEBMENTION_IO_TOKEN");
-/** Overridable so a build can be pointed at fixture data instead of the live API. */
-const readApi = () => readEnv("WEBMENTION_IO_API") || DEFAULT_API;
-
-let cached: Map<string, Webmention[]> | null = null;
-
-/**
- * All received mentions, grouped by normalised target URL. Fetched once per
- * build and memoised, so every page reuses the same result.
- */
-export const getWebmentions = async (): Promise<Map<string, Webmention[]>> => {
-  if (cached) return cached;
-
+const load = async (): Promise<Map<string, Webmention[]>> => {
   const grouped = new Map<string, Webmention[]>();
-  cached = grouped;
-
   if (!webmention.enable) return grouped;
 
-  const token = readToken();
-  if (!token) {
-    console.warn(
-      "[webmention] WEBMENTION_IO_TOKEN is not set - building without received mentions.",
-    );
-    return grouped;
-  }
+  const mentions = await fetchWebmentions({
+    api: readEnv("WEBMENTION_IO_API") || DEFAULT_API,
+    domain: webmention.domain,
+    token: readEnv("WEBMENTION_IO_TOKEN"),
+  });
 
-  const api = readApi();
-  const collected: Webmention[] = [];
-  try {
-    for (let page = 0; page < MAX_PAGES; page++) {
-      const url =
-        `${api}?domain=${encodeURIComponent(webmention.domain)}` +
-        `&token=${encodeURIComponent(token)}&per-page=${PER_PAGE}&page=${page}`;
-
-      const response = await fetch(url, { signal: AbortSignal.timeout(15000) });
-      if (!response.ok) {
-        console.warn(`[webmention] webmention.io responded ${response.status} - skipping.`);
-        break;
-      }
-
-      const body = (await response.json()) as { children?: Webmention[] };
-      const batch = Array.isArray(body?.children) ? body.children : [];
-      collected.push(...batch);
-
-      if (batch.length < PER_PAGE) break;
-    }
-  } catch (error) {
-    console.warn(
-      `[webmention] could not reach webmention.io (${(error as Error)?.message ?? error}) - building without received mentions.`,
-    );
-    return grouped;
-  }
-
-  for (const mention of collected) {
+  for (const mention of mentions) {
     const target = mention["wm-target"];
     if (!target) continue;
     const key = normalizeTarget(target);
@@ -89,6 +41,24 @@ export const getWebmentions = async (): Promise<Map<string, Webmention[]>> => {
     else grouped.set(key, [mention]);
   }
 
-  console.info(`[webmention] ${collected.length} mention(s) across ${grouped.size} page(s).`);
+  if (mentions.length > 0) {
+    console.info(`[webmention] ${mentions.length} mention(s) across ${grouped.size} page(s).`);
+  }
   return grouped;
+};
+
+/**
+ * Memoised on the *promise*, not the result.
+ *
+ * Caching the map itself would publish an empty container to any caller that
+ * arrives while the first fetch is still in flight, and that page would render
+ * "no mentions" even though it has some. Holding the promise makes every
+ * caller await the same completed result, regardless of how Astro schedules
+ * page rendering.
+ */
+let pending: Promise<Map<string, Webmention[]>> | null = null;
+
+export const getWebmentions = (): Promise<Map<string, Webmention[]>> => {
+  pending ??= load();
+  return pending;
 };

--- a/src/utils/getWebmentions.ts
+++ b/src/utils/getWebmentions.ts
@@ -16,8 +16,8 @@ const DEFAULT_API = "https://webmention.io/api/mentions.jf2";
 
 // import.meta.env covers .env files loaded by Vite; process.env covers CI and
 // Netlify build environment variables.
-const readEnv = (name: string): string | undefined => {
-  const fromVite = (import.meta as any)?.env?.[name];
+const readEnv = (name: keyof ImportMetaEnv): string | undefined => {
+  const fromVite = import.meta.env?.[name];
   const fromNode = typeof process !== "undefined" ? process.env?.[name] : undefined;
   return fromVite || fromNode || undefined;
 };
@@ -59,6 +59,12 @@ const load = async (): Promise<Map<string, Webmention[]>> => {
 let pending: Promise<Map<string, Webmention[]>> | null = null;
 
 export const getWebmentions = (): Promise<Map<string, Webmention[]>> => {
-  pending ??= load();
+  // load() is not expected to reject, but a memoised rejection would poison
+  // every remaining page of the build, so the guarantee is made explicit here
+  // rather than relied on.
+  pending ??= load().catch((error) => {
+    console.warn(`[webmention] unexpected failure (${error?.message ?? error}) - skipping.`);
+    return new Map<string, Webmention[]>();
+  });
   return pending;
 };

--- a/src/utils/webmentionFetch.ts
+++ b/src/utils/webmentionFetch.ts
@@ -66,10 +66,12 @@ export const fetchWebmentions = async ({
       if (batch.length < perPage) break;
     }
   } catch (error) {
+    // Keep whatever earlier pages returned rather than discarding them: a
+    // blip on page 3 should cost that page, not the two that already
+    // succeeded. Matches how the non-OK branch above breaks out.
     warn(
-      `[webmention] could not reach webmention.io (${(error as Error)?.message ?? error}) - building without received mentions.`,
+      `[webmention] could not reach webmention.io (${(error as Error)?.message ?? error}) - using ${collected.length} mention(s) fetched so far.`,
     );
-    return [];
   }
 
   return collected;

--- a/src/utils/webmentionFetch.ts
+++ b/src/utils/webmentionFetch.ts
@@ -1,0 +1,76 @@
+import type { Webmention } from "./webmentionFormat";
+
+/**
+ * The network half of webmention fetching, kept free of value imports and
+ * module state so the failure paths can be unit tested directly.
+ *
+ * It never throws and never rejects. A missing token, an unreachable host, a
+ * non-OK response or malformed JSON all resolve to an empty list plus a
+ * warning, because a build must not fail when a third-party service is having
+ * a bad day.
+ */
+
+export type FetchWebmentionsOptions = {
+  api: string;
+  domain: string;
+  token?: string;
+  perPage?: number;
+  maxPages?: number;
+  /** Injectable so tests can drive the failure paths without a server. */
+  fetchImpl?: typeof fetch;
+  warn?: (message: string) => void;
+  timeoutMs?: number;
+};
+
+export const fetchWebmentions = async ({
+  api,
+  domain,
+  token,
+  perPage = 500,
+  maxPages = 20,
+  fetchImpl,
+  warn = console.warn,
+  timeoutMs = 15000,
+}: FetchWebmentionsOptions): Promise<Webmention[]> => {
+  if (!token) {
+    warn("[webmention] WEBMENTION_IO_TOKEN is not set - building without received mentions.");
+    return [];
+  }
+
+  const doFetch = fetchImpl ?? globalThis.fetch;
+  if (typeof doFetch !== "function") {
+    warn("[webmention] no fetch implementation available - skipping.");
+    return [];
+  }
+
+  const collected: Webmention[] = [];
+
+  try {
+    for (let page = 0; page < maxPages; page++) {
+      const url =
+        `${api}?domain=${encodeURIComponent(domain)}` +
+        `&token=${encodeURIComponent(token)}&per-page=${perPage}&page=${page}`;
+
+      const response = await doFetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+
+      if (!response?.ok) {
+        warn(`[webmention] webmention.io responded ${response?.status} - skipping.`);
+        break;
+      }
+
+      const body = (await response.json()) as { children?: Webmention[] };
+      const batch = Array.isArray(body?.children) ? body.children : [];
+      collected.push(...batch);
+
+      // A short page means there is nothing after it.
+      if (batch.length < perPage) break;
+    }
+  } catch (error) {
+    warn(
+      `[webmention] could not reach webmention.io (${(error as Error)?.message ?? error}) - building without received mentions.`,
+    );
+    return [];
+  }
+
+  return collected;
+};

--- a/src/utils/webmentionFormat.ts
+++ b/src/utils/webmentionFormat.ts
@@ -26,6 +26,13 @@ export type Webmention = {
   "wm-received"?: string;
 };
 
+/**
+ * These two lists are an intentional allowlist, not an exhaustive one. A
+ * mention whose wm-property is neither (rsvp, follow-of, and anything
+ * webmention.io adds later) is deliberately not rendered, rather than being
+ * guessed at and shown in a category that misrepresents it.
+ */
+
 /** Reactions worth counting rather than quoting. */
 export const REACTION_PROPERTIES = ["like-of", "repost-of", "bookmark-of"] as const;
 /** Mentions worth showing with their text. */

--- a/src/utils/webmentionFormat.ts
+++ b/src/utils/webmentionFormat.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure helpers for handling received webmentions.
+ *
+ * Deliberately free of imports and side effects: everything here operates on
+ * untrusted third-party data, so it is kept separate from the fetching layer
+ * and unit tested directly (see tests/webmention.test.mjs).
+ */
+
+export type WebmentionAuthor = {
+  name?: string;
+  url?: string;
+  photo?: string;
+};
+
+/** A single mention in webmention.io's jf2 shape. */
+export type Webmention = {
+  author?: WebmentionAuthor;
+  url?: string;
+  published?: string | null;
+  content?: { text?: string; html?: string };
+  "wm-id"?: number;
+  "wm-source"?: string;
+  "wm-target"?: string;
+  /** in-reply-to | like-of | repost-of | bookmark-of | mention-of */
+  "wm-property"?: string;
+  "wm-received"?: string;
+};
+
+/** Reactions worth counting rather than quoting. */
+export const REACTION_PROPERTIES = ["like-of", "repost-of", "bookmark-of"] as const;
+/** Mentions worth showing with their text. */
+export const RESPONSE_PROPERTIES = ["in-reply-to", "mention-of"] as const;
+
+/**
+ * Targets are compared after normalising, because the URL someone linked to
+ * rarely matches ours byte for byte -- trailing slashes, query strings,
+ * fragments and host casing all differ in practice.
+ */
+export const normalizeTarget = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    parsed.search = "";
+    parsed.hostname = parsed.hostname.toLowerCase();
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    return parsed.href.replace(/\/+$/, "");
+  } catch {
+    return url.replace(/\/+$/, "").toLowerCase();
+  }
+};
+
+/**
+ * Only http(s) links may be rendered. Mention data comes from arbitrary
+ * external sites, so a javascript:, data: or vbscript: URL must never reach
+ * an href attribute.
+ */
+export const safeExternalUrl = (value?: string): string | undefined => {
+  if (!value) return undefined;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.href : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/** A display name for a mention, falling back to the source host. */
+export const displayName = (mention: Webmention): string => {
+  const name = mention.author?.name?.trim();
+  if (name) return name;
+  const source = safeExternalUrl(mention["wm-source"] ?? mention.url);
+  if (!source) return "Someone";
+  try {
+    return new URL(source).hostname.replace(/^www\./, "");
+  } catch {
+    return "Someone";
+  }
+};
+
+/** Mentions received by one page, from a map keyed by normalised target. */
+export const mentionsFor = (
+  all: Map<string, Webmention[]>,
+  target: string,
+): Webmention[] => all.get(normalizeTarget(target)) ?? [];

--- a/tests/microformats.test.mjs
+++ b/tests/microformats.test.mjs
@@ -154,6 +154,51 @@ describe("rel=me / rel=author — identity links", () => {
   }
 });
 
+describe("Webmention — endpoint discovery", () => {
+  // A sending site fetches one of our pages and looks for these to know where
+  // to POST. Without them nobody can notify us that they linked here.
+  for (const [label, page] of [
+    ["homepage", ""],
+    ["an entry page", "why-is-writing-important"],
+    ["/posts/", "posts"],
+  ]) {
+    test(`${label} advertises a webmention endpoint`, () => {
+      const rels = parsePage(page).rels;
+      assert.ok(
+        (rels.webmention ?? []).some((url) => url.includes("webmention.io")),
+        `no rel="webmention" on ${label}`,
+      );
+      assert.ok((rels.pingback ?? []).length > 0, `no rel="pingback" on ${label}`);
+    });
+  }
+});
+
+describe("u-in-reply-to — journal replies", () => {
+  // Journal entries that respond to something elsewhere should say so in a way
+  // a receiving site can read, rather than only in prose.
+  const withReplyContext = entriesInFeed("journal").filter((relPath) => {
+    const entry = rootsOfType(parsePage(relPath), "h-entry")[0];
+    return entry && prop(entry, "in-reply-to").length > 0;
+  });
+
+  test("some journal entries publish reply context", () => {
+    assert.ok(
+      withReplyContext.length > 0,
+      "no journal entry exposes u-in-reply-to — the externalUrl markup may have regressed",
+    );
+  });
+
+  test("every reply target is an absolute http(s) URL", () => {
+    for (const relPath of withReplyContext) {
+      const entry = rootsOfType(parsePage(relPath), "h-entry")[0];
+      for (const value of prop(entry, "in-reply-to")) {
+        const url = typeof value === "string" ? value : value?.value;
+        assert.match(url ?? "", /^https?:\/\//, `bad in-reply-to on ${relPath}: ${url}`);
+      }
+    }
+  });
+});
+
 describe("h-entry — content pages", () => {
   // Every entry page is checked, not a sample. Templates are shared, so one
   // page per collection would catch a template regression — but not a page

--- a/tests/webmention.test.mjs
+++ b/tests/webmention.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the webmention helpers.
+ *
+ * These operate on data supplied by whoever sent the mention, so the URL
+ * handling is a security boundary rather than a formatting detail. Imported
+ * directly from source (not from built output) because the module is pure and
+ * has no dependencies -- see tests/microformats.test.mjs for the markup checks.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  safeExternalUrl,
+  normalizeTarget,
+  displayName,
+  mentionsFor,
+  REACTION_PROPERTIES,
+  RESPONSE_PROPERTIES,
+} from "../src/utils/webmentionFormat.ts";
+
+describe("safeExternalUrl — refuses anything that is not http(s)", () => {
+  for (const hostile of [
+    "javascript:alert(1)",
+    "JavaScript:alert(1)",
+    "  javascript:alert(1)",
+    "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+    "not a url at all",
+    "",
+  ]) {
+    test(`rejects ${JSON.stringify(hostile)}`, () => {
+      assert.equal(safeExternalUrl(hostile), undefined);
+    });
+  }
+
+  test("rejects undefined", () => {
+    assert.equal(safeExternalUrl(undefined), undefined);
+  });
+
+  for (const allowed of ["https://example.com/post", "http://example.com/post"]) {
+    test(`allows ${allowed}`, () => {
+      assert.equal(safeExternalUrl(allowed), allowed);
+    });
+  }
+});
+
+describe("normalizeTarget — matches URLs that differ only cosmetically", () => {
+  const canonical = "https://candost.blog/journal/entry";
+
+  for (const variant of [
+    "https://candost.blog/journal/entry",
+    "https://candost.blog/journal/entry/",
+    "https://candost.blog/journal/entry//",
+    "https://CANDOST.blog/journal/entry/",
+    "https://candost.blog/journal/entry/#section",
+    "https://candost.blog/journal/entry/?utm_source=rss",
+  ]) {
+    test(`${variant} normalises to the same target`, () => {
+      assert.equal(normalizeTarget(variant), normalizeTarget(canonical));
+    });
+  }
+
+  test("keeps genuinely different paths apart", () => {
+    assert.notEqual(
+      normalizeTarget("https://candost.blog/journal/one"),
+      normalizeTarget("https://candost.blog/journal/two"),
+    );
+  });
+});
+
+describe("mentionsFor — looks up by normalised target", () => {
+  const mention = { "wm-target": "https://candost.blog/a/", "wm-property": "in-reply-to" };
+  const all = new Map([[normalizeTarget("https://candost.blog/a/"), [mention]]]);
+
+  test("finds mentions when the trailing slash differs", () => {
+    assert.deepEqual(mentionsFor(all, "https://candost.blog/a"), [mention]);
+  });
+
+  test("returns an empty list for a page with none", () => {
+    assert.deepEqual(mentionsFor(all, "https://candost.blog/b/"), []);
+  });
+});
+
+describe("displayName — falls back sensibly", () => {
+  test("prefers the author name", () => {
+    assert.equal(displayName({ author: { name: "Molly White" } }), "Molly White");
+  });
+
+  test("ignores a blank author name", () => {
+    assert.equal(
+      displayName({ author: { name: "   " }, "wm-source": "https://tantek.com/notes/2" }),
+      "tantek.com",
+    );
+  });
+
+  test("falls back to the source host without www.", () => {
+    assert.equal(displayName({ "wm-source": "https://www.example.com/x" }), "example.com");
+  });
+
+  test("does not leak a hostile source into the name", () => {
+    assert.equal(displayName({ "wm-source": "javascript:alert(1)" }), "Someone");
+  });
+
+  test("handles a mention with nothing usable", () => {
+    assert.equal(displayName({}), "Someone");
+  });
+});
+
+describe("property groupings are disjoint", () => {
+  test("no property is both a reaction and a response", () => {
+    const overlap = REACTION_PROPERTIES.filter((p) => RESPONSE_PROPERTIES.includes(p));
+    assert.deepEqual(overlap, []);
+  });
+});

--- a/tests/webmention.test.mjs
+++ b/tests/webmention.test.mjs
@@ -16,6 +16,7 @@ import {
   REACTION_PROPERTIES,
   RESPONSE_PROPERTIES,
 } from "../src/utils/webmentionFormat.ts";
+import { fetchWebmentions } from "../src/utils/webmentionFetch.ts";
 
 describe("safeExternalUrl — refuses anything that is not http(s)", () => {
   for (const hostile of [
@@ -110,5 +111,140 @@ describe("property groupings are disjoint", () => {
   test("no property is both a reaction and a response", () => {
     const overlap = REACTION_PROPERTIES.filter((p) => RESPONSE_PROPERTIES.includes(p));
     assert.deepEqual(overlap, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+/** A fetch stand-in returning one jf2 page. */
+const okResponse = (children) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ children }),
+});
+
+const silent = () => {};
+
+describe("fetchWebmentions — never fails the build", () => {
+  test("returns nothing when the token is missing", async () => {
+    const warnings = [];
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: undefined,
+      warn: (m) => warnings.push(m),
+      fetchImpl: () => assert.fail("must not call the API without a token"),
+    });
+    assert.deepEqual(result, []);
+    assert.match(warnings.join(" "), /WEBMENTION_IO_TOKEN is not set/);
+  });
+
+  test("returns nothing when the API responds non-OK", async () => {
+    const warnings = [];
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      warn: (m) => warnings.push(m),
+      fetchImpl: async () => ({ ok: false, status: 503, json: async () => ({}) }),
+    });
+    assert.deepEqual(result, []);
+    assert.match(warnings.join(" "), /responded 503/);
+  });
+
+  test("returns nothing when the network throws", async () => {
+    const warnings = [];
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      warn: (m) => warnings.push(m),
+      fetchImpl: async () => {
+        throw new Error("ENOTFOUND");
+      },
+    });
+    assert.deepEqual(result, []);
+    assert.match(warnings.join(" "), /could not reach webmention.io/);
+  });
+
+  test("returns nothing when the response is not valid JSON", async () => {
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      warn: silent,
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError("Unexpected token <");
+        },
+      }),
+    });
+    assert.deepEqual(result, []);
+  });
+
+  test("tolerates JSON without a children array", async () => {
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      warn: silent,
+      fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({ children: null }) }),
+    });
+    assert.deepEqual(result, []);
+  });
+});
+
+describe("fetchWebmentions — pagination", () => {
+  test("stops on the first short page", async () => {
+    let calls = 0;
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      perPage: 2,
+      warn: silent,
+      fetchImpl: async () => {
+        calls++;
+        return okResponse(calls === 1 ? [{ "wm-id": 1 }, { "wm-id": 2 }] : [{ "wm-id": 3 }]);
+      },
+    });
+    assert.equal(calls, 2, "should stop once a page comes back short");
+    assert.equal(result.length, 3);
+  });
+
+  test("honours maxPages when every page is full", async () => {
+    let calls = 0;
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      perPage: 1,
+      maxPages: 3,
+      warn: silent,
+      fetchImpl: async () => {
+        calls++;
+        return okResponse([{ "wm-id": calls }]);
+      },
+    });
+    assert.equal(calls, 3, "must not page forever");
+    assert.equal(result.length, 3);
+  });
+
+  test("passes the token and domain to the API", async () => {
+    let seen = "";
+    await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "secret token",
+      warn: silent,
+      fetchImpl: async (url) => {
+        seen = url;
+        return okResponse([]);
+      },
+    });
+    assert.match(seen, /domain=candost\.blog/);
+    assert.match(seen, /token=secret%20token/);
   });
 });

--- a/tests/webmention.test.mjs
+++ b/tests/webmention.test.mjs
@@ -196,6 +196,76 @@ describe("fetchWebmentions — never fails the build", () => {
   });
 });
 
+describe("fetchWebmentions — a late failure keeps earlier pages", () => {
+  test("a network throw on page 2 does not discard pages 0 and 1", async () => {
+    let calls = 0;
+    const warnings = [];
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      perPage: 2,
+      warn: (m) => warnings.push(m),
+      fetchImpl: async () => {
+        calls++;
+        if (calls <= 2) return okResponse([{ "wm-id": calls * 10 }, { "wm-id": calls * 10 + 1 }]);
+        throw new Error("ECONNRESET");
+      },
+    });
+    assert.equal(result.length, 4, "the four mentions already fetched must survive");
+    assert.deepEqual(
+      result.map((m) => m["wm-id"]),
+      [10, 11, 20, 21],
+    );
+    assert.match(warnings.join(" "), /4 mention\(s\) fetched so far/);
+  });
+
+  test("malformed JSON on page 2 does not discard page 1", async () => {
+    let calls = 0;
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      perPage: 1,
+      warn: silent,
+      fetchImpl: async () => {
+        calls++;
+        if (calls === 1) return okResponse([{ "wm-id": 1 }]);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new SyntaxError("Unexpected token <");
+          },
+        };
+      },
+    });
+    assert.deepEqual(
+      result.map((m) => m["wm-id"]),
+      [1],
+    );
+  });
+
+  test("a non-OK page 2 also keeps page 1", async () => {
+    let calls = 0;
+    const result = await fetchWebmentions({
+      api: "https://example.com/api",
+      domain: "candost.blog",
+      token: "t",
+      perPage: 1,
+      warn: silent,
+      fetchImpl: async () => {
+        calls++;
+        return calls === 1 ? okResponse([{ "wm-id": 1 }]) : { ok: false, status: 500 };
+      },
+    });
+    assert.deepEqual(
+      result.map((m) => m["wm-id"]),
+      [1],
+    );
+  });
+});
+
 describe("fetchWebmentions — pagination", () => {
   test("stops on the first short page", async () => {
     let calls = 0;


### PR DESCRIPTION
Tier 2 of the IndieWeb work, following [Andros Fenollosa's article](https://en.andros.dev/blog/0b8e451e/i-joined-the-indieweb-heres-what-i-learned/). **Sending webmentions is deliberately excluded** from this batch.

Builds on #81 — signing in to webmention.io uses the `rel="me"` links that shipped there.

> **This can merge before the webmention.io account exists.** Without `WEBMENTION_IO_TOKEN` the site builds exactly as it does today and renders no mentions.

## Endpoint discovery

`rel="webmention"` and `rel="pingback"` in the document head. A sending site fetches one of our pages, finds these, and POSTs `source` + `target`. A static site has no server to receive that, so webmention.io accepts them on our behalf.

## Fetching

`src/utils/getWebmentions.ts` pulls received mentions once per build, memoised across all 979 pages, paginated, grouped by target URL.

**Every failure path degrades quietly.** No token, unreachable API, non-OK response, or malformed JSON each produce zero mentions and a warning — never a failed build. Publishing must not depend on a third-party service being reachable; the mentions are an enhancement, not the content.

Targets are normalised before matching, because the URL someone linked to rarely matches ours byte for byte — trailing slashes, query strings, fragments and host casing all differ in practice.

`WEBMENTION_IO_API` can point a build at fixture data instead of the live service, for local testing.

## Display

`Webmentions.astro` renders a **"Mentioned elsewhere"** reference list at the foot of each entry, deliberately kept separate from the Waline comments — comments are replies left *here*, these are links from someone else's own site. That separation is Fenollosa's own arrangement, and it fits your existing email-reply affordance. Likes and reposts are counted; replies and mentions are quoted. Nothing renders on a page with no mentions.

## Treating mention data as hostile

This is the part worth reviewing closely. The content comes from whoever sent the mention:

- Only `content.text` is rendered — **never** `content.html`, which is markup from a site we don't control
- Every `href` is scheme-checked, so `javascript:`, `data:` and `vbscript:` URLs are dropped and the author falls back to plain text
- Author avatars are **not** hotlinked from arbitrary third-party servers

Verified end-to-end against a fixture containing a `javascript:` author URL, a `<script>` in `content.html`, and an injected `<img onerror=...>` in `content.text`. Rendered output for the hostile entry:

```html
<li class="text-sm"><p class="mb-1"><strong>Evil Actor</strong><span> mentioned this</span>
<span class="italic"> on 2026-08-02</span></p>
<blockquote class="italic opacity-90">&lt;img src=x onerror=alert(1)&gt; injected text</blockquote></li>
```

No literal tag, no `href` at all, injected markup escaped to text.

## u-in-reply-to

Journal entries with an `externalUrl` already displayed "In response to". That link now carries `u-in-reply-to`, so a receiving site can render it as a genuine reply rather than a bare mention. Four entries currently have reply context.

## Tests — 72, up from 41

The pure helpers are split into `webmentionFormat.ts` (no imports, no side effects) so the security-relevant logic is unit-testable rather than only reachable through a build:

| Added | |
|---|---|
| `safeExternalUrl` | rejects `javascript:` (incl. mixed case and leading whitespace), `data:`, `vbscript:`, `file:`, garbage, empty, undefined; allows http/https |
| `normalizeTarget` | six cosmetic URL variants collapse to one target; genuinely different paths stay apart |
| `mentionsFor` | finds mentions across a trailing-slash mismatch |
| `displayName` | falls back to source host, strips `www.`, refuses to leak a hostile source into the name |
| markup | endpoint discovery on homepage/entry/listing pages; `u-in-reply-to` present and absolute |

The runner now uses `--experimental-strip-types` to load the `.ts` helper. **Verified against Node 22.12.0 — the version `.nvmrc` pins for CI — not just the newer local runtime**, since the flag's behaviour differs across 22.x.

## To activate after merge

1. Sign in at [webmention.io](https://webmention.io) with `candost.blog` (works now that `rel="me"` is live)
2. Copy the API token from its settings
3. Add `WEBMENTION_IO_TOKEN` as a Netlify build environment variable
4. Redeploy — received mentions start rendering

Until then the site is unchanged.

## Not in this batch

- **Sending webmentions** — excluded by request. Fenollosa's pattern is a daily job with a 24-hour margin to fix typos before notifying anyone.
- **Vouch / Salmention** — anti-spam and thread propagation; only worth it once there's real traffic.
- **Bridgy backfeed and Bridgy Fed** — both depend on this receiving path working first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMB6njnh8uGDzxVnTu1Xh1)_